### PR TITLE
Automatically retry on HttpDispatch errors

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -71,6 +71,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8aac770f1885fd7e387acedd76065302551364496e46b3dd00860b2f8359b9d"
 
 [[package]]
+name = "backoff"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "721c249ab59cbc483ad4294c9ee2671835c1e43e9ffc277e6b4ecfef733cfdc5"
+dependencies = [
+ "futures-core",
+ "instant",
+ "pin-project",
+ "rand 0.7.3",
+ "tokio",
+]
+
+[[package]]
 name = "base-x"
 version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -334,6 +347,7 @@ name = "esthri"
 version = "2.1.4"
 dependencies = [
  "anyhow",
+ "backoff",
  "clap",
  "ctrlc",
  "env_logger",
@@ -685,6 +699,12 @@ checksum = "c398b2b113b55809ceb9ee3e753fcbac793f1956663f3c36549c1346015c2afe"
 dependencies = [
  "autocfg",
 ]
+
+[[package]]
+name = "instant"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5b141fdc7836c525d4d594027d318c84161ca17aaf8113ab1f81ab93ae897485"
 
 [[package]]
 name = "iovec"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,7 +5,7 @@ path = "src/main.rs"
 [package]
 name = "esthri"
 version = "2.1.4"
-authors = [ "Jason Mobarak <jason@swift-nav.com>",]
+authors = ["Jason Mobarak <jason@swift-nav.com>"]
 edition = "2018"
 
 [dependencies]
@@ -28,6 +28,7 @@ hyper = "0.13.7"
 hyper-tls = "0.4.3"
 log-derive = "0.4.1"
 futures = "0.3.5"
+backoff = { version = "0.2.1", features = ["tokio"] }
 
 [dev-dependencies]
 md5 = "0.7"
@@ -42,4 +43,4 @@ aggressive_lint = []
 
 [dependencies.ctrlc]
 version = "3.1"
-features = [ "termination",]
+features = ["termination"]

--- a/src/retry.rs
+++ b/src/retry.rs
@@ -1,0 +1,30 @@
+use std::time::Duration;
+
+use backoff::{future::FutureOperation as _, ExponentialBackoff};
+use futures::Future;
+use rusoto_core::{RusotoError, RusotoResult};
+
+pub async fn handle_dispatch_error<'a, T, E, F>(func: impl Fn() -> F + 'a) -> RusotoResult<T, E>
+where
+    F: Future<Output = RusotoResult<T, E>>,
+    E: std::error::Error + Send + Sync + 'static,
+{
+    (|| async { func().await.map_err(from_rusoto_err::<E>) })
+        .retry(default_backoff())
+        .await
+}
+
+fn from_rusoto_err<E>(err: RusotoError<E>) -> backoff::Error<RusotoError<E>> {
+    match err {
+        RusotoError::HttpDispatch(_) => backoff::Error::Transient(err),
+        _ => backoff::Error::Permanent(err),
+    }
+}
+
+fn default_backoff() -> ExponentialBackoff {
+    ExponentialBackoff {
+        max_interval: Duration::from_secs(10),
+        max_elapsed_time: Some(Duration::from_secs(45)),
+        ..Default::default()
+    }
+}


### PR DESCRIPTION
It's a little clunky because the S3 apis take all their params by value. So in order to retry an op, you need to create the input inside the closure, or clone it inside the closure. Cloning is not optimal because if the retry doesn't trigger than you just cloned for no reason. Most of the calls we can go the first route. 

The only exception is upload_from_reader, where we can't create the payload inside the closure, because creating the input requires reading from a `dyn Read`, which I don't think is repeatable