### PR TITLE
Setup graceful handler for SIGINT/SIGTERM [SITL-62]

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -44,7 +44,7 @@ path = "src/lib.rs"
 [features]
 default = [ "http_server",]
 aggressive_lint = []
-http_server = [ "async-tar", "async-compression", "async-stream", "bytes", "futures-util", "mime_guess", "sluice", "sanitize-filename", "serde", "serde_derive", "tokio-util", "warp",]
+http_server = [ "async-tar", "async-compression", "async-stream", "bytes", "futures-util", "mime_guess", "sluice", "sanitize-filename", "serde", "serde_derive", "tokio-util", "warp", "ctrlc"]
 
 [dependencies.tokio]
 version = "0.2"
@@ -107,3 +107,4 @@ optional = true
 [dependencies.ctrlc]
 version = "3.1"
 features = [ "termination",]
+optional = true

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -571,7 +571,7 @@ where
     ))
 }
 
-pub fn setup_cancel_handler() {
+pub fn setup_upload_ctrlc_handler() {
     ctrlc::set_handler(move || {
         let global_data = GLOBAL_DATA.lock().expect(EXPECT_GLOBAL_DATA);
         if global_data.bucket.is_none()

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -571,7 +571,10 @@ where
     ))
 }
 
-pub fn setup_upload_ctrlc_handler() {
+/// Since large uploads require us to create a multi-part upload request
+/// we need to tell AWS that we're aborting the upload, otherwise the
+/// unfinished could stick around indefinitely.
+pub fn setup_upload_termination_handler() {
     ctrlc::set_handler(move || {
         let global_data = GLOBAL_DATA.lock().expect(EXPECT_GLOBAL_DATA);
         if global_data.bucket.is_none()

--- a/src/main.rs
+++ b/src/main.rs
@@ -162,7 +162,7 @@ async fn main() -> Result<()> {
 
     match cli.cmd {
         Put { bucket, key, file } => {
-            setup_upload_ctrlc_handler();
+            setup_upload_termination_handler();
             upload(&s3, &bucket, &key, &file).await?;
         }
 
@@ -199,7 +199,7 @@ async fn main() -> Result<()> {
             include,
             exclude,
         } => {
-            setup_upload_ctrlc_handler();
+            setup_upload_termination_handler();
             sync(
                 &s3, direction, &bucket, &key, &directory, &include, &exclude,
             )

--- a/src/main.rs
+++ b/src/main.rs
@@ -158,12 +158,11 @@ async fn main() -> Result<()> {
     let credentials_provider = DefaultCredentialsProvider::new().unwrap();
     let s3 = S3Client::new_with(http_client, credentials_provider, Region::default());
 
-    setup_cancel_handler();
-
     use Command::*;
 
     match cli.cmd {
         Put { bucket, key, file } => {
+            setup_upload_ctrlc_handler();
             upload(&s3, &bucket, &key, &file).await?;
         }
 
@@ -200,6 +199,7 @@ async fn main() -> Result<()> {
             include,
             exclude,
         } => {
+            setup_upload_ctrlc_handler();
             sync(
                 &s3, direction, &bucket, &key, &directory, &include, &exclude,
             )


### PR DESCRIPTION
Use warp "graceful shutdown" features so that the SIGTERM received from kubernetes will initiate a clean shutdown of connections.  We'll still need to configure timeouts in kubernetes to something longer than the default (60 seconds), the graceful shutdown will not allow new connections, but will allow existing downloads/browsing to continue until they complete.