### PR TITLE
Support the W/ prefix for If-None-Match

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -42,16 +42,18 @@ pipeline {
           }
           steps {
             gitPrep()
-            script {
-              sh("""/bin/bash -ex
-                  |
-                  | git lfs install
-                  | git lfs pull
-                  |
-                  | RUST_LOG=debug RUST_BACKTRACE=1 \\
-                  |   cargo test --features http_server -- --nocapture
-                  |
-                 """.stripMargin())
+            lock(resource: "esthri-integration-tests") {
+              script {
+                sh("""/bin/bash -ex
+                    |
+                    | git lfs install
+                    | git lfs pull
+                    |
+                    | RUST_LOG=debug RUST_BACKTRACE=1 \\
+                    |   cargo test --features http_server -- --nocapture
+                    |
+                   """.stripMargin())
+              }
             }
           }
         }

--- a/src/http_server.rs
+++ b/src/http_server.rs
@@ -505,6 +505,7 @@ async fn item_pre_response<'a, T: S3 + Send>(
         }
     };
     let not_modified = if_none_match
+        .map(|etag| etag.strip_prefix("W/").map(String::from).unwrap_or(etag))
         .map(|etag| etag == obj_info.e_tag)
         .unwrap_or(false);
     if not_modified {


### PR DESCRIPTION
The `W/` prefix is a supported form for etags which requests a "weak comparison": https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/If-None-Match -- the docs state that this is "meaningless" for if-none-match but is nonetheless supported.