### PR TITLE
parallel upload chunks [SITL-248]

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -620,6 +620,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "envy"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f47e0157f2cb54f5ae1bd371b30a2ae4311e1c028f575cd4e81de7353215965"
+dependencies = [
+ "serde",
+]
+
+[[package]]
 name = "esthri"
 version = "5.1.2"
 dependencies = [
@@ -633,6 +642,7 @@ dependencies = [
  "chrono",
  "ctrlc",
  "env_logger",
+ "envy",
  "flate2",
  "futures",
  "futures-util",

--- a/src/esthri/Cargo.toml
+++ b/src/esthri/Cargo.toml
@@ -23,6 +23,7 @@ futures = "0.3"
 thiserror = "1.0"
 chrono = "0.4"
 regex = "1"
+envy = "0.4"
 
 [dev-dependencies]
 md5 = "0.7"

--- a/src/esthri/src/blocking.rs
+++ b/src/esthri/src/blocking.rs
@@ -48,7 +48,7 @@ where
 #[tokio::main]
 pub async fn upload<T, P, SR0, SR1>(s3: &T, bucket: SR0, key: SR1, file: P) -> Result<()>
 where
-    T: S3 + Send,
+    T: S3 + Send + Clone,
     P: AsRef<Path>,
     SR0: AsRef<str>,
     SR1: AsRef<str>,
@@ -65,7 +65,7 @@ pub async fn upload_from_reader<T, SR0, SR1>(
     file_size: u64,
 ) -> Result<()>
 where
-    T: S3 + Send,
+    T: S3 + Send + Clone,
     SR0: AsRef<str>,
     SR1: AsRef<str>,
 {
@@ -92,7 +92,7 @@ pub async fn sync<T, SR0, SR1>(
     excludes: Option<&[SR1]>,
 ) -> Result<()>
 where
-    T: S3 + Send,
+    T: S3 + Send + Clone,
     SR0: AsRef<str>,
     SR1: AsRef<str>,
 {

--- a/src/esthri/src/config.rs
+++ b/src/esthri/src/config.rs
@@ -1,0 +1,65 @@
+use once_cell::sync::OnceCell;
+use serde::Deserialize;
+
+// This is the default chunk size from awscli
+const CHUNK_SIZE: u64 = 8 * 1024 * 1024;
+const XFER_COUNT: usize = 16;
+const READ_SIZE: usize = 4096;
+
+#[derive(Deserialize)]
+pub struct Config {
+    #[serde(default)]
+    pub chunk_size: ChunkSize,
+    #[serde(default)]
+    pub xfer_count: XferCount,
+    #[serde(default)]
+    pub read_size: ReadSize,
+}
+
+#[derive(Deserialize)]
+#[serde(transparent)]
+pub struct ChunkSize(u64);
+
+impl Default for ChunkSize {
+    fn default() -> Self {
+        ChunkSize(CHUNK_SIZE)
+    }
+}
+
+#[derive(Deserialize)]
+#[serde(transparent)]
+pub struct XferCount(usize);
+
+impl Default for XferCount {
+    fn default() -> Self {
+        XferCount(XFER_COUNT)
+    }
+}
+
+#[derive(Deserialize)]
+#[serde(transparent)]
+pub struct ReadSize(usize);
+
+impl Default for ReadSize {
+    fn default() -> Self {
+        ReadSize(READ_SIZE)
+    }
+}
+
+pub static CONFIG: OnceCell<Config> = OnceCell::new();
+
+const EXPECT_GLOBAL_CONFIG: &str = "failed to parse config from environment";
+
+impl Config {
+    pub fn global() -> &'static Config {
+        CONFIG.get_or_init(|| {
+            envy::prefixed("ESTHRI_").from_env::<Config>().expect(EXPECT_GLOBAL_CONFIG)
+        })
+    }
+
+    pub fn read_size(&self) -> usize { self.read_size.0 }
+
+    pub fn chunk_size(&self) -> u64 { self.chunk_size.0 }
+
+    pub fn xfer_count(&self) -> usize { self.xfer_count.0 }
+}

--- a/src/esthri/src/config.rs
+++ b/src/esthri/src/config.rs
@@ -53,13 +53,21 @@ const EXPECT_GLOBAL_CONFIG: &str = "failed to parse config from environment";
 impl Config {
     pub fn global() -> &'static Config {
         CONFIG.get_or_init(|| {
-            envy::prefixed("ESTHRI_").from_env::<Config>().expect(EXPECT_GLOBAL_CONFIG)
+            envy::prefixed("ESTHRI_")
+                .from_env::<Config>()
+                .expect(EXPECT_GLOBAL_CONFIG)
         })
     }
 
-    pub fn read_size(&self) -> usize { self.read_size.0 }
+    pub fn read_size(&self) -> usize {
+        self.read_size.0
+    }
 
-    pub fn chunk_size(&self) -> u64 { self.chunk_size.0 }
+    pub fn chunk_size(&self) -> u64 {
+        self.chunk_size.0
+    }
 
-    pub fn xfer_count(&self) -> usize { self.xfer_count.0 }
+    pub fn xfer_count(&self) -> usize {
+        self.xfer_count.0
+    }
 }

--- a/src/esthri/src/config.rs
+++ b/src/esthri/src/config.rs
@@ -21,8 +21,8 @@ pub struct Config {
     /// The number of workers to use in the when transferring files or running a sync operation.
     #[serde(default)]
     worker_count: WorkerCount,
-    #[serde(default)]
     /// The size of internal buffers used to for file reads.
+    #[serde(default)]
     read_size: ReadSize,
 }
 
@@ -67,9 +67,9 @@ impl Config {
     /// Fetches the global config object, values are either defaulted or populated
     /// from the environment:
     ///
-    /// - `ESTHRI_READ_SIZE` -> [Config::read_size()]
-    /// - `ESTHRI_CHUNK_SIZE` -> [Config::chunk_size()]
-    /// - `ESTHRI_WORKER_COUNT` -> [Config::worker_count()]
+    /// - `ESTHRI_READ_SIZE` - [Config::read_size()]
+    /// - `ESTHRI_CHUNK_SIZE` - [Config::chunk_size()]
+    /// - `ESTHRI_WORKER_COUNT` - [Config::worker_count()]
     pub fn global() -> &'static Config {
         CONFIG.get_or_init(|| {
             envy::prefixed("ESTHRI_")

--- a/src/esthri/src/http_server.rs
+++ b/src/esthri/src/http_server.rs
@@ -134,9 +134,9 @@ impl ErrorTrackerArc {
     }
 }
 
-impl Into<Option<io::Error>> for ErrorTrackerArc {
-    fn into(self) -> Option<io::Error> {
-        let the_error = self.0.the_error.lock().unwrap();
+impl From<ErrorTrackerArc> for Option<io::Error> {
+    fn from(s: ErrorTrackerArc) -> Option<io::Error> {
+        let the_error = s.0.the_error.lock().unwrap();
         let the_error = {
             if let Some(the_error) = &*the_error {
                 the_error

--- a/src/esthri/src/lib.rs
+++ b/src/esthri/src/lib.rs
@@ -278,10 +278,10 @@ where
             create_chunk_upload_stream(chunk_stream, s3.clone(), upload_id.clone(), bucket, key)
                 .await;
 
-        let xfer_count = Config::global().xfer_count();
+        let worker_count = Config::global().worker_count();
 
         let mut completed_parts: Vec<CompletedPart> = upload_stream
-            .buffer_unordered(xfer_count)
+            .buffer_unordered(worker_count)
             .try_collect()
             .await?;
 

--- a/src/esthri/src/lib.rs
+++ b/src/esthri/src/lib.rs
@@ -66,7 +66,7 @@ static GLOBAL_DATA: Lazy<Mutex<GlobalData>> = Lazy::new(|| {
 
 // This is the default chunk size from awscli
 const CHUNK_SIZE: u64 = 8 * 1024 * 1024;
-const PARALLEL_UPLOAD_COUNT: usize = 4;
+const PARALLEL_UPLOAD_COUNT: usize = 16;
 
 const READ_SIZE: usize = 4096;
 


### PR DESCRIPTION
Running with one transfer:
```
$ time ESTHRI_XFER_COUNT=1 cargo run -- put 256MiB.bin --bucket esthri-test --key 256MiB.bin
...

real    0m13.340s
user    0m0.647s
sys     0m0.212s
```

Running with the default (16) transfers:
```
$ time cargo run -- put 256MiB.bin --bucket esthri-test --key 256MiB.bin
...

real    0m4.200s
user    0m0.767s
sys     0m0.359s
```

Running with the old code:
```
$ time cargo run -- put 256MiB.bin --bucket esthri-test --key 256MiB.bin
...

real    0m44.631s
user    0m0.567s
sys     0m0.318s
```