### PR TITLE
parallel download support [SITL-248]

### DIFF
--- a/src/esthri/src/blocking.rs
+++ b/src/esthri/src/blocking.rs
@@ -75,7 +75,7 @@ where
 #[tokio::main]
 pub async fn download<T, P, SR0, SR1>(s3: &T, bucket: SR0, key: SR1, file: P) -> Result<()>
 where
-    T: S3 + Send,
+    T: S3 + Send + Clone,
     P: AsRef<Path>,
     SR0: AsRef<str>,
     SR1: AsRef<str>,

--- a/src/esthri/src/config.rs
+++ b/src/esthri/src/config.rs
@@ -8,9 +8,9 @@ use serde::Deserialize;
 /// size from awscli.
 pub const CHUNK_SIZE: u64 = 8 * 1024 * 1024;
 /// The default number of workers to use in the when transferring files or running a sync operation.
-pub const WORKER_COUNT: usize = 16;
+pub const WORKER_COUNT: u16 = 16;
 /// The default size of internal buffers used to for file reads.
-pub const READ_SIZE: usize = 4096;
+pub const READ_SIZE: usize = 8 * 1024 * 1024;
 
 /// Holds configuration information for the library.
 #[derive(Deserialize)]
@@ -40,7 +40,7 @@ impl Default for ChunkSize {
 /// Wrapper type for [WORKER_COUNT] and [Config::worker_count()] to bind a default value.
 #[derive(Deserialize)]
 #[serde(transparent)]
-struct WorkerCount(usize);
+struct WorkerCount(u16);
 
 impl Default for WorkerCount {
     fn default() -> Self {
@@ -91,7 +91,8 @@ impl Config {
 
     /// The number of workers to use in the when transferring files or running a sync operation.
     /// See [WORKER_COUNT].
-    pub fn worker_count(&self) -> usize {
-        self.worker_count.0
+    pub fn worker_count(&self, multiplier: f64) -> usize {
+        let worker_count = self.worker_count.0 as f64;
+        usize::max(1, (worker_count * multiplier) as usize)
     }
 }

--- a/src/esthri/src/config.rs
+++ b/src/esthri/src/config.rs
@@ -91,8 +91,7 @@ impl Config {
 
     /// The number of workers to use in the when transferring files or running a sync operation.
     /// See [WORKER_COUNT].
-    pub fn worker_count(&self, multiplier: f64) -> usize {
-        let worker_count = self.worker_count.0 as f64;
-        usize::max(1, (worker_count * multiplier) as usize)
+    pub fn worker_count(&self, multiplier: usize) -> usize {
+        self.worker_count.0 as usize * multiplier
     }
 }

--- a/src/esthri/src/config.rs
+++ b/src/esthri/src/config.rs
@@ -111,7 +111,9 @@ impl Config {
     /// The default size of parts in a multipart upload to S3.  8 MiB is the default chunk size
     /// from awscli, changing this size will affect the calculation of ETags.  Defaults to
     /// [UPLOAD_PART_SIZE].
-    pub fn upload_part_size(&self) -> u64 { self.upload_part_size.0 }
+    pub fn upload_part_size(&self) -> u64 {
+        self.upload_part_size.0
+    }
 
     /// The number of concurrent tasks run when sending data to S3.  Defautls to
     /// [CONCURRENT_UPLOAD_TASKS].

--- a/src/esthri/src/config.rs
+++ b/src/esthri/src/config.rs
@@ -1,61 +1,89 @@
-//! Configuration module for the library, allows sizing of internal worker pool sizes, multipart
-//! upload sizes and read buffer sizes, among other things.
+//! Configuration module for the library, allows sizing of internal concurrent task counts,
+//! multipart upload sizes and read buffer sizes, among other things.
 
 use once_cell::sync::OnceCell;
 use serde::Deserialize;
 
-/// The default size of chunks or parts in a multipart upload to S3.  8 MiB is the default chunk
-/// size from awscli.
-pub const CHUNK_SIZE: u64 = 8 * 1024 * 1024;
-/// The default number of workers to use in the when transferring files or running a sync operation.
-pub const WORKER_COUNT: u16 = 16;
-/// The default size of internal buffers used to for file reads.
-pub const READ_SIZE: usize = 8 * 1024 * 1024;
+/// The default size of parts in a multipart upload to S3.  8 MiB is the default chunk
+/// size from awscli, changing this size will affect the calculation of ETags.
+pub const UPLOAD_PART_SIZE: u64 = 8 * 1024 * 1024;
+/// The default number of concurrent tasks run when sending data to S3.
+pub const CONCURRENT_UPLOAD_TASKS: u16 = 16;
+/// When downloading or receiving data from S3, this sizes a task's download buffer.
+pub const DOWNLOAD_BUFFER_SIZE: usize = 8 * 1024 * 1024;
+/// The default number of concurrent tasks run when receiving data from S3.  Each task
+/// represents a connection to S3.
+pub const CONCURRENT_DOWNLOADER_TASKS: u16 = 32;
+/// The default number of concurrent tasks run when writing download data to disk.
+pub const CONCURRENT_WRITER_TASKS: u16 = 64;
 
 /// Holds configuration information for the library.
 #[derive(Deserialize)]
 pub struct Config {
-    /// The size of chunks or parts in a multipart upload to S3.  Default value is 8 MiB.
     #[serde(default)]
-    chunk_size: ChunkSize,
-    /// The number of workers to use in the when transferring files or running a sync operation.
+    upload_part_size: UploadPartSize,
     #[serde(default)]
-    worker_count: WorkerCount,
-    /// The size of internal buffers used to for file reads.
+    concurrent_upload_tasks: ConcurrentUploadTasks,
     #[serde(default)]
-    read_size: ReadSize,
+    download_buffer_size: DownloadBufferSize,
+    #[serde(default)]
+    concurrent_downloader_tasks: ConcurrentDownloaderTasks,
+    #[serde(default)]
+    concurrent_writer_tasks: ConcurrentWriterTasks,
 }
 
-/// Wrapper type for [CHUNK_SIZE] and [Config::chunk_size()] to bind a default value.
+/// Wrapper type for [UPLOAD_PART_SIZE] which allows [Config::upload_part_size()] to bind a default value.
 #[derive(Deserialize)]
 #[serde(transparent)]
-struct ChunkSize(u64);
+struct UploadPartSize(u64);
 
-impl Default for ChunkSize {
+impl Default for UploadPartSize {
     fn default() -> Self {
-        ChunkSize(CHUNK_SIZE)
+        UploadPartSize(UPLOAD_PART_SIZE)
     }
 }
 
-/// Wrapper type for [WORKER_COUNT] and [Config::worker_count()] to bind a default value.
+/// Wrapper type for [CONCURRENT_UPLOAD_TASKS] and [Config::concurrent_upload_tasks()] to bind a default value.
 #[derive(Deserialize)]
 #[serde(transparent)]
-struct WorkerCount(u16);
+struct ConcurrentUploadTasks(u16);
 
-impl Default for WorkerCount {
+impl Default for ConcurrentUploadTasks {
     fn default() -> Self {
-        WorkerCount(WORKER_COUNT)
+        ConcurrentUploadTasks(CONCURRENT_UPLOAD_TASKS)
     }
 }
 
-/// Wrapper type for [READ_SIZE] and [Config::read_size()] to bind a default value.
+/// Wrapper type for [CONCURRENT_DOWNLOADER_TASKS] and [Config::concurrent_downloader_tasks()] to bind a default value.
 #[derive(Deserialize)]
 #[serde(transparent)]
-struct ReadSize(usize);
+struct ConcurrentDownloaderTasks(u16);
 
-impl Default for ReadSize {
+impl Default for ConcurrentDownloaderTasks {
     fn default() -> Self {
-        ReadSize(READ_SIZE)
+        ConcurrentDownloaderTasks(CONCURRENT_DOWNLOADER_TASKS)
+    }
+}
+
+/// Wrapper type for [DOWNLOAD_BUFFER_SIZE] and [Config::download_buffer_size()] to bind a default value.
+#[derive(Deserialize)]
+#[serde(transparent)]
+struct DownloadBufferSize(usize);
+
+impl Default for DownloadBufferSize {
+    fn default() -> Self {
+        DownloadBufferSize(DOWNLOAD_BUFFER_SIZE)
+    }
+}
+
+/// Wrapper type for [CONCURRENT_WRITER_TASKS] and [Config::concurrent_writer_tasks()] to bind a default value.
+#[derive(Deserialize)]
+#[serde(transparent)]
+struct ConcurrentWriterTasks(u16);
+
+impl Default for ConcurrentWriterTasks {
+    fn default() -> Self {
+        ConcurrentWriterTasks(CONCURRENT_WRITER_TASKS)
     }
 }
 
@@ -67,9 +95,11 @@ impl Config {
     /// Fetches the global config object, values are either defaulted or populated
     /// from the environment:
     ///
-    /// - `ESTHRI_READ_SIZE` - [Config::read_size()]
-    /// - `ESTHRI_CHUNK_SIZE` - [Config::chunk_size()]
-    /// - `ESTHRI_WORKER_COUNT` - [Config::worker_count()]
+    /// - `ESTHRI_UPLOAD_PART_SIZE` - [Config::upload_part_size()]
+    /// - `ESTHRI_CONCURRENT_DOWNLOADER_TASKS` - [Config::concurrent_downloader_tasks()]
+    /// - `ESTHRI_DOWNLOAD_BUFFER_SIZE` - [Config::download_buffer_size()]
+    /// - `ESTHRI_CONCURRENT_DOWNLOADER_TASKS` - [Config::concurrent_downloader_tasks()]
+    /// - `ESTHRI_CONCURRENT_WRITER_TASKS` - [Config::concurrent_writer_tasks()]
     pub fn global() -> &'static Config {
         CONFIG.get_or_init(|| {
             envy::prefixed("ESTHRI_")
@@ -78,20 +108,32 @@ impl Config {
         })
     }
 
-    /// The size of internal buffers used to for file reads. See [READ_SIZE].
-    pub fn read_size(&self) -> usize {
-        self.read_size.0
+    /// The default size of parts in a multipart upload to S3.  8 MiB is the default chunk size
+    /// from awscli, changing this size will affect the calculation of ETags.  Defaults to
+    /// [UPLOAD_PART_SIZE].
+    pub fn upload_part_size(&self) -> u64 { self.upload_part_size.0 }
+
+    /// The number of concurrent tasks run when sending data to S3.  Defautls to
+    /// [CONCURRENT_UPLOAD_TASKS].
+    pub fn concurrent_upload_tasks(&self) -> usize {
+        self.concurrent_upload_tasks.0 as usize
     }
 
-    /// The size of chunks or parts in a multipart upload to S3.  Default value is 8 MiB.
-    /// See [CHUNK_SIZE].
-    pub fn chunk_size(&self) -> u64 {
-        self.chunk_size.0
+    /// When downloading or receiving data from S3, this sizes a task's download buffer.  Defaults
+    /// to [DOWNLOAD_BUFFER_SIZE].
+    pub fn download_buffer_size(&self) -> usize {
+        self.download_buffer_size.0
     }
 
-    /// The number of workers to use in the when transferring files or running a sync operation.
-    /// See [WORKER_COUNT].
-    pub fn worker_count(&self, multiplier: usize) -> usize {
-        self.worker_count.0 as usize * multiplier
+    /// The number of concurrent tasks run when receiving data from S3.  Each task represents a
+    /// connection to S3.  Defaults to [CONCURRENT_DOWNLOADER_TASKS].
+    pub fn concurrent_downloader_tasks(&self) -> usize {
+        self.concurrent_downloader_tasks.0 as usize
+    }
+
+    /// The number of concurrent tasks run when writing download data to disk.  Defaults to
+    /// [CONCURRENT_WRITER_TASKS].
+    pub fn concurrent_writer_tasks(&self) -> usize {
+        self.concurrent_writer_tasks.0 as usize
     }
 }

--- a/src/esthri/src/errors.rs
+++ b/src/esthri/src/errors.rs
@@ -89,6 +89,15 @@ pub enum Error {
     #[error(transparent)]
     GetObjectFailed(#[from] RusotoError<GetObjectError>),
 
+    #[error("invalid key, did not exist remotely: {0}")]
+    GetObjectInvalidKey(String),
+
+    #[error("invalid read, sizes did not match {0} and {1}")]
+    GetObjectInvalidRead(usize, usize),
+
+    #[error("remote object sized changed while reading")]
+    GetObjectSizeChanged,
+
     #[error(transparent)]
     IoError(#[from] std::io::Error),
 }

--- a/src/esthri/src/http_server.rs
+++ b/src/esthri/src/http_server.rs
@@ -282,7 +282,7 @@ async fn abort_with_error(
     ErrorTracker::record_error(error_tracker, err);
 }
 
-async fn stream_object_to_archive<T: S3 + Send>(
+async fn stream_object_to_archive<T: S3 + Send + Clone>(
     s3: &T,
     bucket: &str,
     path: &str,

--- a/src/esthri/src/lib.rs
+++ b/src/esthri/src/lib.rs
@@ -351,10 +351,9 @@ struct ReadSize {
 impl ToString for ReadSize {
     fn to_string(&self) -> String {
         format!(
-            "{}-{}/{}",
+            "bytes={}-{}",
             self.offset,
-            self.offset + self.read_size() as u64,
-            self.total
+            self.offset + self.read_size() as u64 - 1,
         )
     }
 }

--- a/src/esthri/src/lib.rs
+++ b/src/esthri/src/lib.rs
@@ -278,7 +278,7 @@ where
             create_chunk_upload_stream(chunk_stream, s3.clone(), upload_id.clone(), bucket, key)
                 .await;
 
-        let worker_count = Config::global().worker_count(1.0);
+        let worker_count = Config::global().worker_count(1);
 
         let mut completed_parts: Vec<CompletedPart> = upload_stream
             .buffer_unordered(worker_count)
@@ -578,13 +578,13 @@ where
 
     let reader_chunk_stream = create_download_readers_stream(s3, bucket, key)
         .await
-        .buffer_unordered(Config::global().worker_count(2.0));
+        .buffer_unordered(Config::global().worker_count(2));
 
     let reader_result_stream =
         map_download_readers_to_writer(reader_chunk_stream, file_output).await;
 
     reader_result_stream
-        .buffer_unordered(Config::global().worker_count(4.0))
+        .buffer_unordered(Config::global().worker_count(4))
         .try_collect()
         .await?;
 

--- a/src/esthri/src/lib.rs
+++ b/src/esthri/src/lib.rs
@@ -404,9 +404,10 @@ fn write_all_at(writer: File, file_offset: u64, buffer: Vec<u8>, length: usize) 
         while length > 0 {
             let write_size = writer.seek_write(&buffer[buffer_offset..length], file_offset).map_err(Error::from)?;
             length -= write_size;
-            file_offset += write_size;
+            file_offset += write_size as u64;
             buffer_offset += write_size;
         }
+        Ok(())
     }
 }
 

--- a/src/esthri/src/types.rs
+++ b/src/esthri/src/types.rs
@@ -123,7 +123,7 @@ pub struct S3Object {
 
 /// Used to track parallel reads when downloading data from S3.
 #[derive(Debug, Clone, Copy)]
-pub (in super) struct ReadSize {
+pub(super) struct ReadSize {
     read_size: usize,
     remaining: u64,
     offset: u64,
@@ -150,7 +150,7 @@ impl ReadSize {
     /// # Arguments
     /// * `read_size` - the size of each read to request from S3
     /// * `total` - the total size of the remote object on S3
-    pub (in super) fn new(read_size: usize, total: u64) -> Self {
+    pub(super) fn new(read_size: usize, total: u64) -> Self {
         ReadSize {
             offset: 0,
             read_size: usize::min(total as usize, read_size),
@@ -159,25 +159,25 @@ impl ReadSize {
         }
     }
     /// Advance the read to the next chunk.
-    pub (in super) fn update(&mut self, amount: usize) -> usize {
+    pub(super) fn update(&mut self, amount: usize) -> usize {
         self.remaining -= amount as u64;
         self.offset += amount as u64;
         self.read_size()
     }
     /// Fetch the next read size
-    pub (in super) fn read_size(&self) -> usize {
+    pub(super) fn read_size(&self) -> usize {
         usize::min(self.remaining as usize, self.read_size)
     }
     /// Indicates if the read process is completed
-    pub (in super) fn complete(&self) -> bool {
+    pub(super) fn complete(&self) -> bool {
         self.remaining == 0
     }
     /// Tracks the total object size on S3
-    pub (in super) fn total(&self) -> u64 {
+    pub(super) fn total(&self) -> u64 {
         self.total
     }
     /// The current read offset
-    pub (in super) fn offset(&self) -> u64 {
+    pub(super) fn offset(&self) -> u64 {
         self.offset
     }
 }

--- a/src/esthri/src/types.rs
+++ b/src/esthri/src/types.rs
@@ -141,7 +141,7 @@ impl ToString for ReadSize {
 }
 
 impl ReadSize {
-    /// Creats an object for tracking read sizes and offsets when requesting data from S3.  Goals
+    /// Creates an object for tracking read sizes and offsets when requesting data from S3.  Goals
     /// are as follows:
     /// * Uses [ToString@ReadSize] to build a Range header value to request data from S3, see the [MDN docs](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Range) and [S3 docs](https://docs.aws.amazon.com/AmazonS3/latest/API/API_GetObject.html#API_GetObject_RequestSyntax) for reference
     /// * Tracks when the end of the object is reached and adjusts the read size accordingly

--- a/src/esthri/src/types.rs
+++ b/src/esthri/src/types.rs
@@ -120,3 +120,64 @@ pub struct S3Object {
     pub key: String,
     pub e_tag: String,
 }
+
+/// Used to track parallel reads when downloading data from S3.
+#[derive(Debug, Clone, Copy)]
+pub (in super) struct ReadSize {
+    read_size: usize,
+    remaining: u64,
+    offset: u64,
+    total: u64,
+}
+
+impl ToString for ReadSize {
+    fn to_string(&self) -> String {
+        format!(
+            "bytes={}-{}",
+            self.offset,
+            self.offset + self.read_size() as u64 - 1,
+        )
+    }
+}
+
+impl ReadSize {
+    /// Creats an object for tracking read sizes and offsets when requesting data from S3.  Goals
+    /// are as follows:
+    /// * Uses [ToString@ReadSize] to build a Range header value to request data from S3, see the [MDN docs](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Range) and [S3 docs](https://docs.aws.amazon.com/AmazonS3/latest/API/API_GetObject.html#API_GetObject_RequestSyntax) for reference
+    /// * Tracks when the end of the object is reached and adjusts the read size accordingly
+    /// * Allows the read process to know if the object size has changed, and abort the read
+    ///
+    /// # Arguments
+    /// * `read_size` - the size of each read to request from S3
+    /// * `total` - the total size of the remote object on S3
+    pub (in super) fn new(read_size: usize, total: u64) -> Self {
+        ReadSize {
+            offset: 0,
+            read_size: usize::min(total as usize, read_size),
+            remaining: total,
+            total,
+        }
+    }
+    /// Advance the read to the next chunk.
+    pub (in super) fn update(&mut self, amount: usize) -> usize {
+        self.remaining -= amount as u64;
+        self.offset += amount as u64;
+        self.read_size()
+    }
+    /// Fetch the next read size
+    pub (in super) fn read_size(&self) -> usize {
+        usize::min(self.remaining as usize, self.read_size)
+    }
+    /// Indicates if the read process is completed
+    pub (in super) fn complete(&self) -> bool {
+        self.remaining == 0
+    }
+    /// Tracks the total object size on S3
+    pub (in super) fn total(&self) -> u64 {
+        self.total
+    }
+    /// The current read offset
+    pub (in super) fn offset(&self) -> u64 {
+        self.offset
+    }
+}


### PR DESCRIPTION
awscli:

```
$ time aws s3 cp s3://esthri-test/256MiB.bin 256MiB.bin.3
download: s3://esthri-test/256MiB.bin to ./256MiB.bin.3

real    0m6.541s
user    0m2.832s
sys     0m1.477s
```

Esthri with this PR:
```
$ time cargo run --release -- get 256MiB.bin.2 --bucket esthri-test --key 256MiB.bin
    Finished release [optimized] target(s) in 0.12s
     Running `env RUST_TEST_THREADS=1 target/release/esthri get 256MiB.bin.2 --bucket esthri-test --key 256MiB.bin`
[2021-05-26T05:40:42Z INFO  esthri] Starting, using region: UsWest2...
[2021-05-26T05:40:42Z INFO  esthri] get: bucket=esthri-test, key=256MiB.bin, file=256MiB.bin.2

real    0m4.572s
user    0m1.729s
sys     0m1.459s
```

Old code before this PR:
```
$ time cargo run --release -- get 256MiB.bin.2 --bucket esthri-test --key 256MiB.bin
    Finished release [optimized] target(s) in 0.11s
     Running `env RUST_TEST_THREADS=1 target/release/esthri get 256MiB.bin.2 --bucket esthri-test --key 256MiB.bin`
[2021-05-26T05:43:14Z INFO  esthri] Starting, using region: UsWest2...
[2021-05-26T05:43:14Z INFO  esthri] get: bucket=esthri-test, key=256MiB.bin, file=256MiB.bin.2
[2021-05-26T05:43:14Z INFO  esthri] get: bucket=esthri-test, key=256MiB.bin

real    0m18.429s
user    0m2.496s
sys     0m3.121s
```