### PR TITLE
concurrent sync support [SITL-248]

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2425,9 +2425,9 @@ checksum = "cda74da7e1a664f795bb1f8a87ec406fb89a02522cf6e50620d016add6dbbf5c"
 
 [[package]]
 name = "tokio"
-version = "1.5.0"
+version = "1.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "83f0c8e7c0addab50b663055baf787d0af7f413a46e6e7fb9559a4e4db7137a5"
+checksum = "bd3076b5c8cc18138b8f8814895c11eb4de37114a5d127bafdc5e55798ceef37"
 dependencies = [
  "autocfg",
  "bytes",

--- a/src/esthri/Cargo.toml
+++ b/src/esthri/Cargo.toml
@@ -37,13 +37,13 @@ name = "esthri"
 path = "src/lib.rs"
 
 [features]
-default = [ "rustls", "cli", "http_server", "blocking", ]
+default = [ "rustls", "cli", "http_server", "blocking", "tokio",]
 aggressive_lint = []
 blocking = []
 http_server = [ "async-tar", "async-compression", "async-stream", "bytes", "futures-util", "mime_guess", "sluice", "sanitize-filename", "serde", "serde_derive", "tokio-util", "warp", "ctrlc", "anyhow"]
 nativetls = [ "rusoto_credential", "rusoto_core/native-tls", "rusoto_signature", "rusoto_s3/native-tls", "hyper-tls",]
 rustls = [ "rusoto_credential", "rusoto_core/rustls", "rusoto_signature", "rusoto_s3/rustls", "hyper-rustls",]
-cli = [ "ctrlc", "structopt", "blocking" ]
+cli = [ "ctrlc", "structopt", "tokio/rt", "tokio/rt-multi-thread",]
 
 [dependencies.anyhow]
 version = "1"
@@ -85,7 +85,8 @@ optional = true
 
 [dependencies.tokio]
 version = "1.6"
-features = [ "io-std", "net", "rt", "time", "rt-multi-thread"]
+features = [ "io-std", "net", "time",]
+optional = true
 
 [dependencies.backoff]
 version = "0.3"

--- a/src/esthri/Cargo.toml
+++ b/src/esthri/Cargo.toml
@@ -24,6 +24,7 @@ thiserror = "1.0"
 chrono = "0.4"
 regex = "1"
 envy = "0.4"
+async-stream = "0.3"
 
 [dev-dependencies]
 md5 = "0.7"
@@ -37,10 +38,10 @@ name = "esthri"
 path = "src/lib.rs"
 
 [features]
-default = [ "rustls", "cli", "http_server", "blocking", "tokio",]
+default = [ "rustls", "cli", "http_server", "blocking",]
 aggressive_lint = []
 blocking = []
-http_server = [ "async-tar", "async-compression", "async-stream", "bytes", "futures-util", "mime_guess", "sluice", "sanitize-filename", "serde", "serde_derive", "tokio-util", "warp", "ctrlc", "anyhow"]
+http_server = [ "async-tar", "async-compression", "bytes", "futures-util", "mime_guess", "sluice", "sanitize-filename", "serde", "serde_derive", "tokio-util", "warp", "ctrlc", "anyhow"]
 nativetls = [ "rusoto_credential", "rusoto_core/native-tls", "rusoto_signature", "rusoto_s3/native-tls", "hyper-tls",]
 rustls = [ "rusoto_credential", "rusoto_core/rustls", "rusoto_signature", "rusoto_s3/rustls", "hyper-rustls",]
 cli = [ "ctrlc", "structopt", "blocking", "tokio/rt-multi-thread",]
@@ -85,8 +86,7 @@ optional = true
 
 [dependencies.tokio]
 version = "1.6"
-features = [ "io-std", "net", "time", "rt",]
-optional = true
+features = [ "io-std", "rt",]
 
 [dependencies.backoff]
 version = "0.3"
@@ -107,10 +107,6 @@ optional = true
 [dependencies.async-compression]
 version = "0.3"
 features = [ "gzip", "futures-io",]
-optional = true
-
-[dependencies.async-stream]
-version = "0.3"
 optional = true
 
 [dependencies.sluice]

--- a/src/esthri/Cargo.toml
+++ b/src/esthri/Cargo.toml
@@ -84,8 +84,8 @@ version = "0.3"
 optional = true
 
 [dependencies.tokio]
-version = "1.5"
-features = [ "io-std", "net", "rt", "time",]
+version = "1.6"
+features = [ "io-std", "net", "rt", "time", "rt-multi-thread"]
 
 [dependencies.backoff]
 version = "0.3"

--- a/src/esthri/Cargo.toml
+++ b/src/esthri/Cargo.toml
@@ -43,7 +43,7 @@ blocking = []
 http_server = [ "async-tar", "async-compression", "async-stream", "bytes", "futures-util", "mime_guess", "sluice", "sanitize-filename", "serde", "serde_derive", "tokio-util", "warp", "ctrlc", "anyhow"]
 nativetls = [ "rusoto_credential", "rusoto_core/native-tls", "rusoto_signature", "rusoto_s3/native-tls", "hyper-tls",]
 rustls = [ "rusoto_credential", "rusoto_core/rustls", "rusoto_signature", "rusoto_s3/rustls", "hyper-rustls",]
-cli = [ "ctrlc", "structopt", "tokio/rt", "tokio/rt-multi-thread",]
+cli = [ "ctrlc", "structopt", "blocking", "tokio/rt-multi-thread",]
 
 [dependencies.anyhow]
 version = "1"
@@ -85,7 +85,7 @@ optional = true
 
 [dependencies.tokio]
 version = "1.6"
-features = [ "io-std", "net", "time",]
+features = [ "io-std", "net", "time", "rt",]
 optional = true
 
 [dependencies.backoff]

--- a/src/esthri/Cargo.toml
+++ b/src/esthri/Cargo.toml
@@ -25,6 +25,8 @@ chrono = "0.4"
 regex = "1"
 envy = "0.4"
 async-stream = "0.3"
+serde = "1"
+serde_derive = "1"
 
 [dev-dependencies]
 md5 = "0.7"
@@ -41,7 +43,7 @@ path = "src/lib.rs"
 default = [ "rustls", "cli", "http_server", "blocking",]
 aggressive_lint = []
 blocking = []
-http_server = [ "async-tar", "async-compression", "bytes", "futures-util", "mime_guess", "sluice", "sanitize-filename", "serde", "serde_derive", "tokio-util", "warp", "ctrlc", "anyhow"]
+http_server = [ "async-tar", "async-compression", "bytes", "futures-util", "mime_guess", "sluice", "sanitize-filename", "tokio-util", "warp", "ctrlc", "anyhow",]
 nativetls = [ "rusoto_credential", "rusoto_core/native-tls", "rusoto_signature", "rusoto_s3/native-tls", "hyper-tls",]
 rustls = [ "rusoto_credential", "rusoto_core/rustls", "rusoto_signature", "rusoto_s3/rustls", "hyper-rustls",]
 cli = [ "ctrlc", "structopt", "blocking", "tokio/rt-multi-thread",]
@@ -120,14 +122,6 @@ optional = true
 [dependencies.tokio-util]
 version = "0.6"
 features = [ "compat", "codec",]
-optional = true
-
-[dependencies.serde]
-version = "1.0"
-optional = true
-
-[dependencies.serde_derive]
-version = "1.0"
 optional = true
 
 [dependencies.mime_guess]

--- a/src/esthri/Cargo.toml
+++ b/src/esthri/Cargo.toml
@@ -88,7 +88,7 @@ optional = true
 
 [dependencies.tokio]
 version = "1.6"
-features = [ "io-std", "rt",]
+features = [ "rt",]
 
 [dependencies.backoff]
 version = "0.3"

--- a/src/esthri/src/blocking.rs
+++ b/src/esthri/src/blocking.rs
@@ -75,7 +75,7 @@ where
 #[tokio::main]
 pub async fn download<T, P, SR0, SR1>(s3: &T, bucket: SR0, key: SR1, file: P) -> Result<()>
 where
-    T: S3 + Send,
+    T: S3 + Send + Clone,
     P: AsRef<Path>,
     SR0: AsRef<str>,
     SR1: AsRef<str>,

--- a/src/esthri/src/config.rs
+++ b/src/esthri/src/config.rs
@@ -8,9 +8,9 @@ use serde::Deserialize;
 /// size from awscli.
 pub const CHUNK_SIZE: u64 = 8 * 1024 * 1024;
 /// The default number of workers to use in the when transferring files or running a sync operation.
-pub const WORKER_COUNT: usize = 16;
+pub const WORKER_COUNT: u16 = 16;
 /// The default size of internal buffers used to for file reads.
-pub const READ_SIZE: usize = 4096;
+pub const READ_SIZE: usize = 8 * 1024 * 1024;
 
 /// Holds configuration information for the library.
 #[derive(Deserialize)]
@@ -40,7 +40,7 @@ impl Default for ChunkSize {
 /// Wrapper type for [WORKER_COUNT] and [Config::worker_count()] to bind a default value.
 #[derive(Deserialize)]
 #[serde(transparent)]
-struct WorkerCount(usize);
+struct WorkerCount(u16);
 
 impl Default for WorkerCount {
     fn default() -> Self {
@@ -91,7 +91,8 @@ impl Config {
 
     /// The number of workers to use in the when transferring files or running a sync operation.
     /// See [WORKER_COUNT].
-    pub fn worker_count(&self) -> usize {
-        self.worker_count.0
+    pub fn worker_count(&self, multiplier: f64) -> usize {
+        let worker_count = self.worker_count.0 as f64;
+        usize::max(1, (worker_count * multiplier) as usize)
     }
 }

--- a/src/esthri/src/config.rs
+++ b/src/esthri/src/config.rs
@@ -16,6 +16,8 @@ pub const DOWNLOAD_BUFFER_SIZE: usize = 8 * 1024 * 1024;
 pub const CONCURRENT_DOWNLOADER_TASKS: u16 = 32;
 /// The default number of concurrent tasks run when writing download data to disk.
 pub const CONCURRENT_WRITER_TASKS: u16 = 64;
+/// The default number of concurrent tasks run when running a sync operation
+pub const CONCURRENT_SYNC_TASKS: u16 = 16;
 
 /// Holds configuration information for the library.
 #[derive(Deserialize)]
@@ -30,9 +32,12 @@ pub struct Config {
     concurrent_downloader_tasks: ConcurrentDownloaderTasks,
     #[serde(default)]
     concurrent_writer_tasks: ConcurrentWriterTasks,
+    #[serde(default)]
+    concurrent_sync_tasks: ConcurrentSyncTasks,
 }
 
-/// Wrapper type for [UPLOAD_PART_SIZE] which allows [Config::upload_part_size()] to bind a default value.
+/// Wrapper type for [UPLOAD_PART_SIZE] which allows [Config::upload_part_size()] to bind a default
+/// value.
 #[derive(Deserialize)]
 #[serde(transparent)]
 struct UploadPartSize(u64);
@@ -43,7 +48,8 @@ impl Default for UploadPartSize {
     }
 }
 
-/// Wrapper type for [CONCURRENT_UPLOAD_TASKS] and [Config::concurrent_upload_tasks()] to bind a default value.
+/// Wrapper type for [CONCURRENT_UPLOAD_TASKS] which allows [Config::concurrent_upload_tasks()] to
+/// bind a default value.
 #[derive(Deserialize)]
 #[serde(transparent)]
 struct ConcurrentUploadTasks(u16);
@@ -54,7 +60,8 @@ impl Default for ConcurrentUploadTasks {
     }
 }
 
-/// Wrapper type for [CONCURRENT_DOWNLOADER_TASKS] and [Config::concurrent_downloader_tasks()] to bind a default value.
+/// Wrapper type for [CONCURRENT_DOWNLOADER_TASKS] which allows
+/// [Config::concurrent_downloader_tasks()] to bind a default value.
 #[derive(Deserialize)]
 #[serde(transparent)]
 struct ConcurrentDownloaderTasks(u16);
@@ -65,7 +72,8 @@ impl Default for ConcurrentDownloaderTasks {
     }
 }
 
-/// Wrapper type for [DOWNLOAD_BUFFER_SIZE] and [Config::download_buffer_size()] to bind a default value.
+/// Wrapper type for [DOWNLOAD_BUFFER_SIZE] which allows [Config::download_buffer_size()] to bind a
+/// default value.
 #[derive(Deserialize)]
 #[serde(transparent)]
 struct DownloadBufferSize(usize);
@@ -76,7 +84,8 @@ impl Default for DownloadBufferSize {
     }
 }
 
-/// Wrapper type for [CONCURRENT_WRITER_TASKS] and [Config::concurrent_writer_tasks()] to bind a default value.
+/// Wrapper type for [CONCURRENT_WRITER_TASKS] which allows [Config::concurrent_writer_tasks()] to
+/// bind a default value.
 #[derive(Deserialize)]
 #[serde(transparent)]
 struct ConcurrentWriterTasks(u16);
@@ -84,6 +93,18 @@ struct ConcurrentWriterTasks(u16);
 impl Default for ConcurrentWriterTasks {
     fn default() -> Self {
         ConcurrentWriterTasks(CONCURRENT_WRITER_TASKS)
+    }
+}
+
+/// Wrapper type for [CONCURRENT_SYNC_TASKS] which allows [Config::concurrent_sync_tasks()] to bind
+/// a default value.
+#[derive(Deserialize)]
+#[serde(transparent)]
+struct ConcurrentSyncTasks(u16);
+
+impl Default for ConcurrentSyncTasks {
+    fn default() -> Self {
+        ConcurrentSyncTasks(CONCURRENT_SYNC_TASKS)
     }
 }
 
@@ -137,5 +158,11 @@ impl Config {
     /// [CONCURRENT_WRITER_TASKS].
     pub fn concurrent_writer_tasks(&self) -> usize {
         self.concurrent_writer_tasks.0 as usize
+    }
+
+    /// The number of concurrent tasks run when running a sync operation.  Defaults to
+    /// [CONCURRENT_SYNC_TASKS].
+    pub fn concurrent_sync_tasks(&self) -> usize {
+        self.concurrent_sync_tasks.0 as usize
     }
 }

--- a/src/esthri/src/config.rs
+++ b/src/esthri/src/config.rs
@@ -91,8 +91,7 @@ impl Config {
 
     /// The number of workers to use in the when transferring files or running a sync operation.
     /// See [WORKER_COUNT].
-    pub fn worker_count(&self, multiplier: f64) -> usize {
-        let worker_count = self.worker_count.0 as f64;
-        usize::max(1, (worker_count * multiplier) as usize)
+    pub fn worker_count(&self, multiplier: usize) -> usize {
+        self.worker_count.0 as usize * multiplier
     }
 }

--- a/src/esthri/src/config.rs
+++ b/src/esthri/src/config.rs
@@ -111,7 +111,9 @@ impl Config {
     /// The default size of parts in a multipart upload to S3.  8 MiB is the default chunk size
     /// from awscli, changing this size will affect the calculation of ETags.  Defaults to
     /// [UPLOAD_PART_SIZE].
-    pub fn upload_part_size(&self) -> u64 { self.upload_part_size.0 }
+    pub fn upload_part_size(&self) -> u64 {
+        self.upload_part_size.0
+    }
 
     /// The number of concurrent tasks run when sending data to S3.  Defautls to
     /// [CONCURRENT_UPLOAD_TASKS].

--- a/src/esthri/src/config.rs
+++ b/src/esthri/src/config.rs
@@ -1,61 +1,89 @@
-//! Configuration module for the library, allows sizing of internal worker pool sizes, multipart
-//! upload sizes and read buffer sizes, among other things.
+//! Configuration module for the library, allows sizing of internal concurrent task counts,
+//! multipart upload sizes and read buffer sizes, among other things.
 
 use once_cell::sync::OnceCell;
 use serde::Deserialize;
 
-/// The default size of chunks or parts in a multipart upload to S3.  8 MiB is the default chunk
-/// size from awscli.
-pub const CHUNK_SIZE: u64 = 8 * 1024 * 1024;
-/// The default number of workers to use in the when transferring files or running a sync operation.
-pub const WORKER_COUNT: u16 = 16;
-/// The default size of internal buffers used to for file reads.
-pub const READ_SIZE: usize = 8 * 1024 * 1024;
+/// The default size of parts in a multipart upload to S3.  8 MiB is the default chunk
+/// size from awscli, changing this size will affect the calculation of ETags.
+pub const UPLOAD_PART_SIZE: u64 = 8 * 1024 * 1024;
+/// The default number of concurrent tasks run when sending data to S3.
+pub const CONCURRENT_UPLOAD_TASKS: u16 = 16;
+/// When downloading or receiving data from S3, this sizes a task's download buffer.
+pub const DOWNLOAD_BUFFER_SIZE: usize = 8 * 1024 * 1024;
+/// The default number of concurrent tasks run when receiving data from S3.  Each task
+/// represents a connection to S3.
+pub const CONCURRENT_DOWNLOADER_TASKS: u16 = 32;
+/// The default number of concurrent tasks run when writing download data to disk.
+pub const CONCURRENT_WRITER_TASKS: u16 = 64;
 
 /// Holds configuration information for the library.
 #[derive(Deserialize)]
 pub struct Config {
-    /// The size of chunks or parts in a multipart upload to S3.  Default value is 8 MiB.
     #[serde(default)]
-    chunk_size: ChunkSize,
-    /// The number of workers to use in the when transferring files or running a sync operation.
+    upload_part_size: UploadPartSize,
     #[serde(default)]
-    worker_count: WorkerCount,
-    /// The size of internal buffers used to for file reads.
+    concurrent_upload_tasks: ConcurrentUploadTasks,
     #[serde(default)]
-    read_size: ReadSize,
+    download_buffer_size: DownloadBufferSize,
+    #[serde(default)]
+    concurrent_downloader_tasks: ConcurrentDownloaderTasks,
+    #[serde(default)]
+    concurrent_writer_tasks: ConcurrentWriterTasks,
 }
 
-/// Wrapper type for [CHUNK_SIZE] and [Config::chunk_size()] to bind a default value.
+/// Wrapper type for [UPLOAD_PART_SIZE] which allows [Config::upload_part_size()] to bind a default value.
 #[derive(Deserialize)]
 #[serde(transparent)]
-struct ChunkSize(u64);
+struct UploadPartSize(u64);
 
-impl Default for ChunkSize {
+impl Default for UploadPartSize {
     fn default() -> Self {
-        ChunkSize(CHUNK_SIZE)
+        UploadPartSize(UPLOAD_PART_SIZE)
     }
 }
 
-/// Wrapper type for [WORKER_COUNT] and [Config::worker_count()] to bind a default value.
+/// Wrapper type for [CONCURRENT_UPLOAD_TASKS] and [Config::concurrent_upload_tasks()] to bind a default value.
 #[derive(Deserialize)]
 #[serde(transparent)]
-struct WorkerCount(u16);
+struct ConcurrentUploadTasks(u16);
 
-impl Default for WorkerCount {
+impl Default for ConcurrentUploadTasks {
     fn default() -> Self {
-        WorkerCount(WORKER_COUNT)
+        ConcurrentUploadTasks(CONCURRENT_UPLOAD_TASKS)
     }
 }
 
-/// Wrapper type for [READ_SIZE] and [Config::read_size()] to bind a default value.
+/// Wrapper type for [CONCURRENT_DOWNLOADER_TASKS] and [Config::concurrent_downloader_tasks()] to bind a default value.
 #[derive(Deserialize)]
 #[serde(transparent)]
-struct ReadSize(usize);
+struct ConcurrentDownloaderTasks(u16);
 
-impl Default for ReadSize {
+impl Default for ConcurrentDownloaderTasks {
     fn default() -> Self {
-        ReadSize(READ_SIZE)
+        ConcurrentDownloaderTasks(CONCURRENT_DOWNLOADER_TASKS)
+    }
+}
+
+/// Wrapper type for [DOWNLOAD_BUFFER_SIZE] and [Config::download_buffer_size()] to bind a default value.
+#[derive(Deserialize)]
+#[serde(transparent)]
+struct DownloadBufferSize(usize);
+
+impl Default for DownloadBufferSize {
+    fn default() -> Self {
+        DownloadBufferSize(DOWNLOAD_BUFFER_SIZE)
+    }
+}
+
+/// Wrapper type for [CONCURRENT_WRITER_TASKS] and [Config::concurrent_writer_tasks()] to bind a default value.
+#[derive(Deserialize)]
+#[serde(transparent)]
+struct ConcurrentWriterTasks(u16);
+
+impl Default for ConcurrentWriterTasks {
+    fn default() -> Self {
+        ConcurrentWriterTasks(CONCURRENT_WRITER_TASKS)
     }
 }
 
@@ -67,9 +95,11 @@ impl Config {
     /// Fetches the global config object, values are either defaulted or populated
     /// from the environment:
     ///
-    /// - `ESTHRI_READ_SIZE` - [Config::read_size()]
-    /// - `ESTHRI_CHUNK_SIZE` - [Config::chunk_size()]
-    /// - `ESTHRI_WORKER_COUNT` - [Config::worker_count()]
+    /// - `ESTHRI_UPLOAD_PART_SIZE` - [Config::upload_part_size()]
+    /// - `ESTHRI_CONCURRENT_DOWNLOADER_TASKS` - [Config::concurrent_downloader_tasks()]
+    /// - `ESTHRI_DOWNLOAD_BUFFER_SIZE` - [Config::download_buffer_size()]
+    /// - `ESTHRI_CONCURRENT_DOWNLOADER_TASKS` - [Config::concurrent_downloader_tasks()]
+    /// - `ESTHRI_CONCURRENT_WRITER_TASKS` - [Config::concurrent_writer_tasks()]
     pub fn global() -> &'static Config {
         CONFIG.get_or_init(|| {
             envy::prefixed("ESTHRI_")
@@ -78,20 +108,32 @@ impl Config {
         })
     }
 
-    /// The size of internal buffers used to for file reads. See [READ_SIZE].
-    pub fn read_size(&self) -> usize {
-        self.read_size.0
+    /// The default size of parts in a multipart upload to S3.  8 MiB is the default chunk size
+    /// from awscli, changing this size will affect the calculation of ETags.  Defaults to
+    /// [UPLOAD_PART_SIZE].
+    pub fn upload_part_size(&self) -> u64 { self.upload_part_size.0 }
+
+    /// The number of concurrent tasks run when sending data to S3.  Defautls to
+    /// [CONCURRENT_UPLOAD_TASKS].
+    pub fn concurrent_upload_tasks(&self) -> usize {
+        self.concurrent_upload_tasks.0 as usize
     }
 
-    /// The size of chunks or parts in a multipart upload to S3.  Default value is 8 MiB.
-    /// See [CHUNK_SIZE].
-    pub fn chunk_size(&self) -> u64 {
-        self.chunk_size.0
+    /// When downloading or receiving data from S3, this sizes a task's download buffer.  Defaults
+    /// to [DOWNLOAD_BUFFER_SIZE].
+    pub fn download_buffer_size(&self) -> usize {
+        self.download_buffer_size.0
     }
 
-    /// The number of workers to use in the when transferring files or running a sync operation.
-    /// See [WORKER_COUNT].
-    pub fn worker_count(&self, multiplier: usize) -> usize {
-        self.worker_count.0 as usize * multiplier
+    /// The number of concurrent tasks run when receiving data from S3.  Each task represents a
+    /// connection to S3.  Defaults to [CONCURRENT_DOWNLOADER_TASKS].
+    pub fn concurrent_downloader_tasks(&self) -> usize {
+        self.concurrent_downloader_tasks.0 as usize
+    }
+
+    /// The number of concurrent tasks run when writing download data to disk.  Defaults to
+    /// [CONCURRENT_WRITER_TASKS].
+    pub fn concurrent_writer_tasks(&self) -> usize {
+        self.concurrent_writer_tasks.0 as usize
     }
 }

--- a/src/esthri/src/errors.rs
+++ b/src/esthri/src/errors.rs
@@ -21,6 +21,7 @@ use rusoto_s3::{
     CreateMultipartUploadError, GetObjectError, HeadObjectError, ListObjectsV2Error,
     PutObjectError, UploadPartError,
 };
+use tokio::task::JoinError;
 
 pub type Result<T> = std::result::Result<T, Error>;
 
@@ -100,6 +101,9 @@ pub enum Error {
 
     #[error(transparent)]
     IoError(#[from] std::io::Error),
+
+    #[error(transparent)]
+    JoinError(#[from] JoinError),
 }
 
 impl From<std::convert::Infallible> for Error {

--- a/src/esthri/src/errors.rs
+++ b/src/esthri/src/errors.rs
@@ -89,6 +89,15 @@ pub enum Error {
     #[error(transparent)]
     GetObjectFailed(#[from] RusotoError<GetObjectError>),
 
+    #[error("invalid key, did not exist remotely: {0}")]
+    GetObjectInvalidKey(String),
+
+    #[error("invalid read, sizes did not match {0} and {1}")]
+    GetObjectInvalidRead(usize, usize),
+
+    #[error("remote object sized changed while reading")]
+    GetObjectSizeChanged,
+
     #[error(transparent)]
     IoError(#[from] std::io::Error),
 }

--- a/src/esthri/src/http_server.rs
+++ b/src/esthri/src/http_server.rs
@@ -366,7 +366,7 @@ async fn create_error_monitor_stream<T: Stream<Item = io::Result<BytesMut>> + Un
                 } else {
                     debug!("wrapped stream done, no error signaled");
                 }
-                break;
+                return;
             }
         }
     }
@@ -460,7 +460,7 @@ async fn create_index_stream(
                 }
                 Err(err) => {
                     yield Err(into_io_error(anyhow!(err)));
-                    break;
+                    return;
                 }
             }
         }
@@ -485,7 +485,7 @@ async fn create_item_stream(
             if let Some(data) = stream.next().await {
                 yield data;
             } else {
-                break;
+                return;
             }
         }
     }

--- a/src/esthri/src/http_server.rs
+++ b/src/esthri/src/http_server.rs
@@ -460,6 +460,7 @@ async fn create_index_stream(
                 }
                 Err(err) => {
                     yield Err(into_io_error(anyhow!(err)));
+                    break;
                 }
             }
         }
@@ -473,13 +474,13 @@ async fn create_item_stream(
     path: String,
 ) -> impl Stream<Item = io::Result<Bytes>> {
     stream! {
-    let mut stream = match download_streaming(&s3, &bucket, &path).await {
-        Ok(byte_stream) => byte_stream,
-        Err(err) => {
-            yield Err(into_io_error(anyhow!(err)));
-            return;
-        }
-    };
+        let mut stream = match download_streaming(&s3, &bucket, &path).await {
+            Ok(byte_stream) => byte_stream,
+            Err(err) => {
+                yield Err(into_io_error(anyhow!(err)));
+                return;
+            }
+        };
         loop {
             if let Some(data) = stream.next().await {
                 yield data;

--- a/src/esthri/src/http_server.rs
+++ b/src/esthri/src/http_server.rs
@@ -282,7 +282,7 @@ async fn abort_with_error(
     ErrorTracker::record_error(error_tracker, err);
 }
 
-async fn stream_object_to_archive<T: S3 + Send>(
+async fn stream_object_to_archive<T: S3 + Send + Clone>(
     s3: &T,
     bucket: &str,
     path: &str,

--- a/src/esthri/src/lib.rs
+++ b/src/esthri/src/lib.rs
@@ -351,10 +351,9 @@ struct ReadSize {
 impl ToString for ReadSize {
     fn to_string(&self) -> String {
         format!(
-            "{}-{}/{}",
+            "bytes={}-{}",
             self.offset,
-            self.offset + self.read_size() as u64,
-            self.total
+            self.offset + self.read_size() as u64 - 1,
         )
     }
 }

--- a/src/esthri/src/lib.rs
+++ b/src/esthri/src/lib.rs
@@ -55,7 +55,7 @@ use crate::retry::handle_dispatch_error;
 use crate::rusoto::*;
 
 use crate::config::Config;
-use crate::types::{GlobalData, ReadSize, S3Listing};
+use crate::types::{GlobalData, ListingMetadata, MapEtagResult, ReadSize, S3Listing};
 pub use crate::types::{ObjectInfo, S3ListingItem, S3Object, SyncParam};
 
 const EXPECT_GLOBAL_DATA: &str = "failed to lock global data";
@@ -72,22 +72,6 @@ static GLOBAL_DATA: Lazy<Mutex<GlobalData>> = Lazy::new(|| {
 
 pub const INCLUDE_EMPTY: Option<&[&str]> = None;
 pub const EXCLUDE_EMPTY: Option<&[&str]> = None;
-
-struct ListingMetadata {
-    s3_suffix: String,
-    e_tag: String,
-}
-
-impl ListingMetadata {
-    fn some(s3_suffix: String, e_tag: String) -> Option<Self> {
-        Some(Self { s3_suffix, e_tag })
-    }
-    fn none() -> Option<Self> {
-        None
-    }
-}
-
-type MapEtagResult = Result<(String, Result<String>, Option<ListingMetadata>)>;
 
 #[logfn(err = "ERROR")]
 pub async fn head_object<T, SR0, SR1>(s3: &T, bucket: SR0, key: SR1) -> Result<Option<ObjectInfo>>

--- a/src/esthri/src/lib.rs
+++ b/src/esthri/src/lib.rs
@@ -278,7 +278,7 @@ where
             create_chunk_upload_stream(chunk_stream, s3.clone(), upload_id.clone(), bucket, key)
                 .await;
 
-        let worker_count = Config::global().worker_count(1.0);
+        let worker_count = Config::global().worker_count(1);
 
         let mut completed_parts: Vec<CompletedPart> = upload_stream
             .buffer_unordered(worker_count)
@@ -578,13 +578,13 @@ where
 
     let reader_chunk_stream = create_download_readers_stream(s3, bucket, key)
         .await
-        .buffer_unordered(Config::global().worker_count(2.0));
+        .buffer_unordered(Config::global().worker_count(2));
 
     let reader_result_stream =
         map_download_readers_to_writer(reader_chunk_stream, file_output).await;
 
     reader_result_stream
-        .buffer_unordered(Config::global().worker_count(4.0))
+        .buffer_unordered(Config::global().worker_count(4))
         .try_collect()
         .await?;
 

--- a/src/esthri/src/lib.rs
+++ b/src/esthri/src/lib.rs
@@ -404,9 +404,10 @@ fn write_all_at(writer: File, file_offset: u64, buffer: Vec<u8>, length: usize) 
         while length > 0 {
             let write_size = writer.seek_write(&buffer[buffer_offset..length], file_offset).map_err(Error::from)?;
             length -= write_size;
-            file_offset += write_size;
+            file_offset += write_size as u64;
             buffer_offset += write_size;
         }
+        Ok(())
     }
 }
 

--- a/src/esthri/src/lib.rs
+++ b/src/esthri/src/lib.rs
@@ -167,10 +167,12 @@ async fn create_file_chunk_stream<R: Read>(
             let mut buf = vec![0u8; upload_part_size as usize];
             if reader.read(&mut buf)? == 0 {
                 yield Err(Error::ReadZero);
+                return;
+            } else {
+                yield Ok((part_number, buf));
+                remaining -= upload_part_size;
+                part_number += 1;
             }
-            yield Ok((part_number, buf));
-            remaining -= upload_part_size;
-            part_number += 1;
         }
     }
 }
@@ -1105,14 +1107,14 @@ fn create_dirent_stream<'a>(
                 entry
             } else {
                 yield Err(entry.err().unwrap().into());
-                break;
+                return;
             };
             let metadata = entry.metadata();
             let stat = if let Ok(stat) = metadata {
                 stat
             } else {
                 yield Err(metadata.err().unwrap().into());
-                break;
+                return;
             };
             if stat.is_dir() {
                 continue;
@@ -1380,7 +1382,7 @@ where
                             }
                         } else {
                             yield Err(path_result.err().unwrap().into());
-                            break;
+                            return;
                         }
                     }
                 } else {
@@ -1388,7 +1390,7 @@ where
                 }
             } else {
                 yield Err(entries_result.err().unwrap());
-                break;
+                return;
             }
         }
     }

--- a/src/esthri/src/main.rs
+++ b/src/esthri/src/main.rs
@@ -23,6 +23,7 @@ use esthri::*;
 use structopt::StructOpt;
 
 use hyper::Client;
+use tokio::runtime::Builder;
 
 #[logfn(err = "ERROR")]
 fn log_etag(path: &str) -> Result<String> {
@@ -117,8 +118,7 @@ enum Command {
     },
 }
 
-#[tokio::main]
-async fn main() -> Result<()> {
+async fn async_main() -> Result<()> {
     if std::env::var("RUST_LOG").is_err() {
         std::env::set_var("RUST_LOG", "esthri=debug,esthri_lib=debug");
     }
@@ -195,4 +195,9 @@ async fn main() -> Result<()> {
     }
 
     Ok(())
+}
+
+fn main() -> Result<()> {
+    let rt = Builder::new_multi_thread().enable_all().build().expect("failed to create tokio runtime");
+    rt.block_on(async { async_main().await })
 }

--- a/src/esthri/src/main.rs
+++ b/src/esthri/src/main.rs
@@ -198,6 +198,9 @@ async fn async_main() -> Result<()> {
 }
 
 fn main() -> Result<()> {
-    let rt = Builder::new_multi_thread().enable_all().build().expect("failed to create tokio runtime");
+    let rt = Builder::new_multi_thread()
+        .enable_all()
+        .build()
+        .expect("failed to create tokio runtime");
     rt.block_on(async { async_main().await })
 }

--- a/src/esthri/src/types.rs
+++ b/src/esthri/src/types.rs
@@ -123,7 +123,7 @@ pub struct S3Object {
 
 /// Used to track parallel reads when downloading data from S3.
 #[derive(Debug, Clone, Copy)]
-pub (in super) struct ReadSize {
+pub(super) struct ReadSize {
     read_size: usize,
     remaining: u64,
     offset: u64,
@@ -150,7 +150,7 @@ impl ReadSize {
     /// # Arguments
     /// * `read_size` - the size of each read to request from S3
     /// * `total` - the total size of the remote object on S3
-    pub (in super) fn new(read_size: usize, total: u64) -> Self {
+    pub(super) fn new(read_size: usize, total: u64) -> Self {
         ReadSize {
             offset: 0,
             read_size: usize::min(total as usize, read_size),
@@ -159,25 +159,25 @@ impl ReadSize {
         }
     }
     /// Advance the read to the next chunk.
-    pub (in super) fn update(&mut self, amount: usize) -> usize {
+    pub(super) fn update(&mut self, amount: usize) -> usize {
         self.remaining -= amount as u64;
         self.offset += amount as u64;
         self.read_size()
     }
     /// Fetch the next read size
-    pub (in super) fn read_size(&self) -> usize {
+    pub(super) fn read_size(&self) -> usize {
         usize::min(self.remaining as usize, self.read_size)
     }
     /// Indicates if the read process is completed
-    pub (in super) fn complete(&self) -> bool {
+    pub(super) fn complete(&self) -> bool {
         self.remaining == 0
     }
     /// Tracks the total object size on S3
-    pub (in super) fn total(&self) -> u64 {
+    pub(super) fn total(&self) -> u64 {
         self.total
     }
     /// The current read offset
-    pub (in super) fn offset(&self) -> u64 {
+    pub(super) fn offset(&self) -> u64 {
         self.offset
     }
 }

--- a/src/esthri/src/types.rs
+++ b/src/esthri/src/types.rs
@@ -11,9 +11,12 @@
 */
 
 use std::path::{Path, PathBuf};
+use std::result::Result as StdResult;
 
 use chrono::{DateTime, Utc};
 use regex::Regex;
+
+use crate::errors::Result;
 
 pub(crate) struct GlobalData {
     pub(crate) bucket: Option<String>,
@@ -51,7 +54,7 @@ impl SyncParam {
 impl std::str::FromStr for SyncParam {
     type Err = String;
 
-    fn from_str(s: &str) -> Result<Self, Self::Err> {
+    fn from_str(s: &str) -> StdResult<Self, Self::Err> {
         let s3_format = Regex::new(r"^s3://(?P<bucket>[^/]+)/(?P<key>.*)$").unwrap();
 
         if let Some(captures) = s3_format.captures(s) {
@@ -181,3 +184,22 @@ impl ReadSize {
         self.offset
     }
 }
+
+/// For syncing from remote to local, or local to remote, "metadata" is attached to the listing in
+/// the remote case (the S3 "suffix" and the ETag) so that we can make the comparison to decide if
+/// we need to download or upload.
+pub(super) struct ListingMetadata {
+    pub(super) s3_suffix: String,
+    pub(super) e_tag: String,
+}
+
+impl ListingMetadata {
+    pub(super) fn some(s3_suffix: String, e_tag: String) -> Option<Self> {
+        Some(Self { s3_suffix, e_tag })
+    }
+    pub(super) fn none() -> Option<Self> {
+        None
+    }
+}
+
+pub(super) type MapEtagResult = Result<(String, Result<String>, Option<ListingMetadata>)>;

--- a/src/esthri/src/types.rs
+++ b/src/esthri/src/types.rs
@@ -18,10 +18,10 @@ use regex::Regex;
 
 use crate::errors::Result;
 
-pub(crate) struct GlobalData {
-    pub(crate) bucket: Option<String>,
-    pub(crate) key: Option<String>,
-    pub(crate) upload_id: Option<String>,
+pub(super) struct GlobalData {
+    pub(super) bucket: Option<String>,
+    pub(super) key: Option<String>,
+    pub(super) upload_id: Option<String>,
 }
 
 #[derive(Debug)]

--- a/src/esthri/src/types.rs
+++ b/src/esthri/src/types.rs
@@ -120,3 +120,64 @@ pub struct S3Object {
     pub key: String,
     pub e_tag: String,
 }
+
+/// Used to track parallel reads when downloading data from S3.
+#[derive(Debug, Clone, Copy)]
+pub (in super) struct ReadSize {
+    read_size: usize,
+    remaining: u64,
+    offset: u64,
+    total: u64,
+}
+
+impl ToString for ReadSize {
+    fn to_string(&self) -> String {
+        format!(
+            "bytes={}-{}",
+            self.offset,
+            self.offset + self.read_size() as u64 - 1,
+        )
+    }
+}
+
+impl ReadSize {
+    /// Creats an object for tracking read sizes and offsets when requesting data from S3.  Goals
+    /// are as follows:
+    /// * Uses [ToString@ReadSize] to build a Range header value to request data from S3, see the [MDN docs](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Range) and [S3 docs](https://docs.aws.amazon.com/AmazonS3/latest/API/API_GetObject.html#API_GetObject_RequestSyntax) for reference
+    /// * Tracks when the end of the object is reached and adjusts the read size accordingly
+    /// * Allows the read process to know if the object size has changed, and abort the read
+    ///
+    /// # Arguments
+    /// * `read_size` - the size of each read to request from S3
+    /// * `total` - the total size of the remote object on S3
+    pub (in super) fn new(read_size: usize, total: u64) -> Self {
+        ReadSize {
+            offset: 0,
+            read_size: usize::min(total as usize, read_size),
+            remaining: total,
+            total,
+        }
+    }
+    /// Advance the read to the next chunk.
+    pub (in super) fn update(&mut self, amount: usize) -> usize {
+        self.remaining -= amount as u64;
+        self.offset += amount as u64;
+        self.read_size()
+    }
+    /// Fetch the next read size
+    pub (in super) fn read_size(&self) -> usize {
+        usize::min(self.remaining as usize, self.read_size)
+    }
+    /// Indicates if the read process is completed
+    pub (in super) fn complete(&self) -> bool {
+        self.remaining == 0
+    }
+    /// Tracks the total object size on S3
+    pub (in super) fn total(&self) -> u64 {
+        self.total
+    }
+    /// The current read offset
+    pub (in super) fn offset(&self) -> u64 {
+        self.offset
+    }
+}

--- a/src/esthri/tests/data/sync_up/nested/2MiB.bin
+++ b/src/esthri/tests/data/sync_up/nested/2MiB.bin
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:34e6a923d0b8d0348ff32c0de5ca6148333defbf9f9d9334db7fe0eb89296135
+size 2097152

--- a/src/esthri/tests/integration/download_test.rs
+++ b/src/esthri/tests/integration/download_test.rs
@@ -23,3 +23,19 @@ async fn test_download_async() {
     let res = download(s3client.as_ref(), crate::TEST_BUCKET, &s3_key, &filepath).await;
     assert!(res.is_ok());
 }
+
+#[tokio::test]
+async fn test_download_zero_size() {
+    let s3client = crate::get_s3client();
+    let _tmp_dir = crate::EphemeralTempDir::pushd();
+
+    // Test object `test_download/test0b.bin` must be prepopulated in the S3 bucket
+    let res = download(s3client.as_ref(), crate::TEST_BUCKET, "test_download/test0b.bin", "test0b.download").await;
+    assert!(res.is_ok());
+
+    let stat = std::fs::metadata("test0b.download");
+    assert!(stat.is_ok());
+
+    let stat = stat.unwrap();
+    assert_eq!(stat.len(), 0);
+}

--- a/src/esthri/tests/integration/download_test.rs
+++ b/src/esthri/tests/integration/download_test.rs
@@ -30,7 +30,13 @@ async fn test_download_zero_size() {
     let _tmp_dir = crate::EphemeralTempDir::pushd();
 
     // Test object `test_download/test0b.bin` must be prepopulated in the S3 bucket
-    let res = download(s3client.as_ref(), crate::TEST_BUCKET, "test_download/test0b.bin", "test0b.download").await;
+    let res = download(
+        s3client.as_ref(),
+        crate::TEST_BUCKET,
+        "test_download/test0b.bin",
+        "test0b.download",
+    )
+    .await;
     assert!(res.is_ok());
 
     let stat = std::fs::metadata("test0b.download");

--- a/src/esthri/tests/integration/sync_test.rs
+++ b/src/esthri/tests/integration/sync_test.rs
@@ -24,7 +24,7 @@ fn test_sync_down() {
         includes.as_deref(),
         excludes.as_deref(),
     );
-    assert!(res.is_ok(), format!("s3_sync result: {:?}", res));
+    assert!(res.is_ok(), "s3_sync result: {:?}", res);
 }
 
 #[tokio::test]
@@ -46,7 +46,7 @@ async fn test_sync_down_async() {
         excludes.as_deref(),
     )
     .await;
-    assert!(res.is_ok(), format!("s3_sync result: {:?}", res));
+    assert!(res.is_ok(), "s3_sync result: {:?}", res);
 }
 
 #[test]
@@ -222,5 +222,5 @@ async fn test_sync_across() {
         excludes.as_deref(),
     )
     .await;
-    assert!(res.is_ok(), format!("s3_sync result: {:?}", res));
+    assert!(res.is_ok(), "s3_sync result: {:?}", res);
 }

--- a/src/esthri/tests/integration/sync_test.rs
+++ b/src/esthri/tests/integration/sync_test.rs
@@ -152,6 +152,7 @@ fn test_sync_up_default() {
         KeyHashPair("1-one.data", "\"827aa1b392c93cb25d2348bdc9b907b0\""),
         KeyHashPair("2-two.bin", "\"35500e07a35b413fc5f434397a4c6bfa\""),
         KeyHashPair("3-three.junk", "\"388f9763d78cecece332459baecb4b85\""),
+        KeyHashPair("nested/2MiB.bin", "\"64a2635e42ef61c69d62feebdbf118d4\""),
     ];
 
     for key_hash_pair in &key_hash_pairs[..] {
@@ -197,6 +198,7 @@ fn test_sync_down_default() {
         KeyHashPair("1-one.data", "827aa1b392c93cb25d2348bdc9b907b0"),
         KeyHashPair("2-two.bin", "35500e07a35b413fc5f434397a4c6bfa"),
         KeyHashPair("3-three.junk", "388f9763d78cecece332459baecb4b85"),
+        KeyHashPair("nested/2MiB.bin", "64a2635e42ef61c69d62feebdbf118d4"),
     ];
 
     validate_key_hash_pairs(local_directory, &key_hash_pairs);


### PR DESCRIPTION
Added tests for a few bugs (introduced while writing this (and the previous) PR, but not caught by unit tests):
- nested directory sync
- downloading a zero length file

Baseline aws sync remote to local:
```
$ time bash -c "aws s3 sync s3://drive-test-logs-2/2021-04/2021-04-27-BayLoop/Ublx_M8L_GLO_ADR431_SBAS_1Hz_AmotechL2 d &>sync_d.log"

real    0m11.524s
user    0m4.426s
sys     0m2.996s
```

New code  (remote to local):
```
$ time bash -c "cargo run --release -- sync --source s3://drive-test-logs-2/2021-04/2021-04-27-BayLoop/Ublx_M8L_GLO_ADR431_SBAS_1Hz_AmotechL2/ --destination d2/ &>sync_d2.log"

real    0m6.510s
user    0m2.961s
sys     0m2.378s
```

Baseline local to remote sync:
```
$ time bash -c "aws s3 sync d s3://drive-test-logs-2/d3 &>sync_d3.log"

real    0m5.412s
user    0m3.248s
sys     0m1.513s
```

New code (local to remote):
```
$ time bash -c "cargo run --release -- sync --source d2/ --destination s3://drive-test-logs-2/d4/ &>sync_d4.log"

real    0m6.116s
user    0m1.729s
sys     0m1.240s
```

Basic validation:
```
$ du -s d
226818  d

$ du -s d2
226818  d2

$ aws s3 sync s3://drive-test-logs-2/d4 d4 &>/dev/null
$ aws s3 sync s3://drive-test-logs-2/d3 d3 &>/dev/null

$ du -s d3 d4
226818  d3
226818  d4
```