### PR TITLE
More cargo additions for crates.io release

### DIFF
--- a/src/esthri/Cargo.toml
+++ b/src/esthri/Cargo.toml
@@ -10,6 +10,11 @@ version = "6.0.1-alpha.0"
 authors = [ "Swift Navigation <dev@swift-nav.com>",]
 edition = "2018"
 license = "MIT"
+repository = "https://github.com/swift-nav/esthri/"
+homepage = "https://github.com/swift-nav/esthri/"
+categories = ["command-line-utilities"]
+keywords = ["aws", "s3"]
+exclude = ["tests/"]
 
 [dependencies]
 once_cell = "1.7"


### PR DESCRIPTION
`exclude` is the only important one here - the release was failing due the tests dir being too big - but I went ahead and added some additional fields while I was at it.