### PR TITLE
Fix github release packaging

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -218,7 +218,6 @@ pipeline {
                 | cargo make --profile release+static build
                 |
                 | cp target/release/esthri \$dir_name
-                | cp bin/aws.esthri \$dir_name
                 |
                 | tar -cvzf \$archive_name \$dir_name
                 |


### PR DESCRIPTION
aws.esthri no longer exists, so the binaries weren't properly pushed for 6.1.0. Will push this as 6.1.1.