### PR TITLE
[DEVINFRA-586] Fix some incompatabilities with AWS tool

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -45,6 +45,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "assert_cmd"
+version = "2.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e996dc7940838b7ef1096b882e29ec30a3149a3a443cdc8dba19ed382eca1fe2"
+dependencies = [
+ "bstr",
+ "doc-comment",
+ "predicates",
+ "predicates-core",
+ "predicates-tree",
+ "wait-timeout",
+]
+
+[[package]]
 name = "async-channel"
 version = "1.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -322,6 +336,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "bstr"
+version = "0.2.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba3569f383e8f1598449f1a423e72e99569137b47740b1da11ef19af3d5c3223"
+dependencies = [
+ "lazy_static",
+ "memchr",
+ "regex-automata",
+]
+
+[[package]]
 name = "buf_redux"
 version = "0.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -527,6 +552,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "difflib"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6184e33543162437515c2e2b48714794e37845ec9851711914eec9d308f6ebe8"
+
+[[package]]
 name = "digest"
 version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -566,6 +597,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "doc-comment"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fea41bba32d969b513997752735605054bc0dfa92b4c56bf1189f2e174be7a10"
+
+[[package]]
+name = "either"
+version = "1.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e78d4f1cc4ae33bbfc157ed5d5a5ef3bc29227303d595861deb238fcec4e9457"
+
+[[package]]
 name = "env_logger"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -592,6 +635,7 @@ name = "esthri"
 version = "6.1.1"
 dependencies = [
  "anyhow",
+ "assert_cmd",
  "async-compression",
  "async-stream",
  "async-tar",
@@ -1132,6 +1176,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "itertools"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "69ddb889f9d0d08a67338271fa9b62996bc788c7796a5c18cf057420aaed5eaf"
+dependencies = [
+ "either",
+]
+
+[[package]]
 name = "itoa"
 version = "0.4.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1243,9 +1296,9 @@ checksum = "490cc448043f947bae3cbee9c203358d62dbee0db12107a74be5c30ccfd09771"
 
 [[package]]
 name = "memchr"
-version = "2.3.4"
+version = "2.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0ee1c47aaa256ecabcaea351eae4a9b01ef39ed810004e298d2511ed284b1525"
+checksum = "308cc39be01b73d0d18f82a0e7b2a3df85245f84af96fdddc5d202d27e47b86a"
 
 [[package]]
 name = "memoffset"
@@ -1539,6 +1592,33 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ac74c624d6b2d21f425f752262f42188365d7b8ff1aff74c82e45136510a4857"
 
 [[package]]
+name = "predicates"
+version = "2.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c6ce811d0b2e103743eec01db1c50612221f173084ce2f7941053e94b6bb474"
+dependencies = [
+ "difflib",
+ "itertools",
+ "predicates-core",
+]
+
+[[package]]
+name = "predicates-core"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "57e35a3326b75e49aa85f5dc6ec15b41108cf5aee58eabb1f274dd18b73c2451"
+
+[[package]]
+name = "predicates-tree"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "338c7be2905b732ae3984a2f40032b5e94fd8f52505b186c7d4d68d193445df7"
+dependencies = [
+ "predicates-core",
+ "termtree",
+]
+
+[[package]]
 name = "proc-macro-error"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1755,6 +1835,12 @@ dependencies = [
  "memchr",
  "regex-syntax",
 ]
+
+[[package]]
+name = "regex-automata"
+version = "0.1.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c230d73fb8d8c1b9c0b3135c5142a8acee3a0558fb8db5cf1cb65f8d7862132"
 
 [[package]]
 name = "regex-syntax"
@@ -2252,6 +2338,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "termtree"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "13a4ec180a2de59b57434704ccfad967f789b12737738798fa08798cd5824c16"
+
+[[package]]
 name = "textwrap"
 version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2568,6 +2660,15 @@ name = "version_check"
 version = "0.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b5a972e5669d67ba988ce3dc826706fb0a8b01471c088cb0b6110b805cc36aed"
+
+[[package]]
+name = "wait-timeout"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9f200f5b12eb75f8c1ed65abd4b2db8a6e1b138a20de009dacee265a2498f3f6"
+dependencies = [
+ "libc",
+]
 
 [[package]]
 name = "waker-fn"

--- a/src/esthri/Cargo.toml
+++ b/src/esthri/Cargo.toml
@@ -42,6 +42,7 @@ flate2 = "1.0"
 tempdir = "0.3"
 backtrace = "0.3"
 fs_extra = "1.2"
+assert_cmd = "2.0.2"
 
 [lib]
 name = "esthri"

--- a/src/esthri/src/errors.rs
+++ b/src/esthri/src/errors.rs
@@ -125,6 +125,9 @@ pub enum Error {
     #[cfg(feature = "cli")]
     #[error(transparent)]
     CliError(#[from] ClapError),
+
+    #[error("Could not parse S3 filename")]
+    CouldNotParseS3Filename,
 }
 
 impl From<std::convert::Infallible> for Error {

--- a/src/esthri/src/ops/download.rs
+++ b/src/esthri/src/ops/download.rs
@@ -420,8 +420,7 @@ where
     let (bucket, key, download_path) = (bucket.as_ref(), key.as_ref(), download_path.as_ref());
 
     // If we're trying to download into a directory, assemble the path for the user
-    let is_dir = download_path.is_dir();
-    let file = if !is_dir {
+    let file = if !download_path.is_dir() {
         download_path.to_path_buf()
     } else {
         let s3filename = key

--- a/src/esthri/src/ops/sync.rs
+++ b/src/esthri/src/ops/sync.rs
@@ -30,8 +30,6 @@ use crate::{
     types::{S3ListingItem, S3PathParam},
 };
 
-const FORWARD_SLASH: char = '/';
-
 type MapEtagResult = Result<(PathBuf, Result<String>, Option<ListingMetadata>)>;
 
 #[logfn(err = "ERROR")]
@@ -328,11 +326,6 @@ where
     T: S3 + Send + Clone,
 {
     let directory = directory.as_ref();
-
-    if !key.ends_with(FORWARD_SLASH) {
-        return Err(Error::DirlikePrefixRequired);
-    }
-
     let task_count = Config::global().concurrent_sync_tasks();
     let dirent_stream = create_dirent_stream(directory, glob_includes, glob_excludes);
     let etag_stream = map_paths_to_etags(dirent_stream, compressed).buffer_unordered(task_count);
@@ -391,14 +384,6 @@ async fn sync_across<T>(
 where
     T: S3 + Send,
 {
-    if !source_prefix.ends_with(FORWARD_SLASH) {
-        return Err(Error::DirlikePrefixRequired);
-    }
-
-    if !destination_key.ends_with(FORWARD_SLASH) {
-        return Err(Error::DirlikePrefixRequired);
-    }
-
     let mut stream = list_objects_stream(s3, source_bucket, source_prefix);
 
     while let Some(from_entries) = stream.try_next().await? {
@@ -544,10 +529,6 @@ where
     T: S3 + Sync + Send + Clone,
 {
     let directory = directory.as_ref();
-    if !key.ends_with(FORWARD_SLASH) {
-        return Err(Error::DirlikePrefixRequired);
-    }
-
     let task_count = Config::global().concurrent_sync_tasks();
     let object_listing =
         flattened_object_listing(s3, bucket, key, directory, glob_includes, glob_excludes);

--- a/src/esthri/tests/integration/cli_test.rs
+++ b/src/esthri/tests/integration/cli_test.rs
@@ -100,7 +100,7 @@ fn test_aws_fallthrough() {
     // and if it doesn't know how to handle the arg
     let assert = cmd
         .env("ESTHRI_AWS_COMPAT_MODE", "1")
-        .env("ESTHRI_AWS_PATH", "/usr/bin/echo")
+        .env("ESTHRI_AWS_PATH", "echo")
         .arg("unknown_command")
         .assert();
 
@@ -114,7 +114,7 @@ fn test_aws_fallthrough_cp_option() {
     // Try with some options we know but one we don't (ls)
     let assert = cmd
         .env("ESTHRI_AWS_COMPAT_MODE", "1")
-        .env("ESTHRI_AWS_PATH", "/usr/bin/echo")
+        .env("ESTHRI_AWS_PATH", "echo")
         .arg("s3")
         .arg("ls")
         .assert();

--- a/src/esthri/tests/integration/cli_test.rs
+++ b/src/esthri/tests/integration/cli_test.rs
@@ -1,0 +1,123 @@
+use assert_cmd::Command;
+use std::fs;
+use tempdir::TempDir;
+
+use crate::{validate_key_hash_pairs, KeyHashPair};
+
+fn test_aws_sync_down(sync_from: &str, sync_to: &str) {
+    let mut cmd = Command::cargo_bin("esthri").unwrap();
+    let assert = cmd
+        .env("ESTHRI_AWS_COMPAT_MODE", "1")
+        .arg("s3")
+        .arg("sync")
+        .arg("--quiet")
+        .arg("--acl")
+        .arg("bucket-owner-full-control")
+        .arg(sync_from)
+        .arg(sync_to)
+        .assert();
+
+    assert.success();
+
+    let key_hash_pairs = [
+        KeyHashPair("1-one.data", "827aa1b392c93cb25d2348bdc9b907b0"),
+        KeyHashPair("2-two.bin", "35500e07a35b413fc5f434397a4c6bfa"),
+        KeyHashPair("3-three.junk", "388f9763d78cecece332459baecb4b85"),
+        KeyHashPair("nested/2MiB.bin", "64a2635e42ef61c69d62feebdbf118d4"),
+    ];
+
+    validate_key_hash_pairs(sync_to, &key_hash_pairs);
+    assert!(fs::remove_dir_all(sync_to).is_ok());
+}
+
+#[test]
+fn test_sync_trailing_slash() {
+    test_aws_sync_down(
+        "s3://esthri-test/test_sync_down_default/",
+        "tests/data/sync_down/cli_down/",
+    );
+}
+
+#[test]
+fn test_sync_no_trailing_slash() {
+    test_aws_sync_down(
+        "s3://esthri-test/test_sync_down_default",
+        "tests/data/sync_down/cli_down",
+    );
+}
+
+#[test]
+fn test_cp_to_dir() {
+    let mut cmd = Command::cargo_bin("esthri").unwrap();
+    let local_dir = TempDir::new("esthri_cli").unwrap();
+    let local_dir_path = local_dir.path().to_str().unwrap();
+    let assert = cmd
+        .env("ESTHRI_AWS_COMPAT_MODE", "1")
+        .arg("s3")
+        .arg("cp")
+        .arg("s3://esthri-test/test_sync_down_default/1-one.data")
+        .arg(local_dir_path)
+        .assert();
+
+    assert.success();
+
+    validate_key_hash_pairs(
+        local_dir_path,
+        &[KeyHashPair(
+            "1-one.data",
+            "827aa1b392c93cb25d2348bdc9b907b0",
+        )],
+    );
+}
+
+#[test]
+fn test_cp_to_file() {
+    let mut cmd = Command::cargo_bin("esthri").unwrap();
+    let local_dir = TempDir::new("esthri_cli").unwrap();
+    let file_path = local_dir.path().join("myfile");
+
+    let assert = cmd
+        .env("ESTHRI_AWS_COMPAT_MODE", "1")
+        .arg("s3")
+        .arg("cp")
+        .arg("s3://esthri-test/test_sync_down_default/1-one.data")
+        .arg(file_path.to_str().unwrap())
+        .assert();
+
+    assert.success();
+
+    validate_key_hash_pairs(
+        local_dir.path().to_str().unwrap(),
+        &[KeyHashPair("myfile", "827aa1b392c93cb25d2348bdc9b907b0")],
+    );
+}
+
+#[test]
+fn test_aws_fallthrough() {
+    let mut cmd = Command::cargo_bin("esthri").unwrap();
+
+    // Esthri should fallback to the AWS executable if invoked in compat mode
+    // and if it doesn't know how to handle the arg
+    let assert = cmd
+        .env("ESTHRI_AWS_COMPAT_MODE", "1")
+        .env("ESTHRI_AWS_PATH", "/usr/bin/echo")
+        .arg("unknown_command")
+        .assert();
+
+    assert.success().stdout("unknown_command\n");
+}
+
+#[test]
+fn test_aws_fallthrough_cp_option() {
+    let mut cmd = Command::cargo_bin("esthri").unwrap();
+
+    // Try with some options we know but one we don't (ls)
+    let assert = cmd
+        .env("ESTHRI_AWS_COMPAT_MODE", "1")
+        .env("ESTHRI_AWS_PATH", "/usr/bin/echo")
+        .arg("s3")
+        .arg("ls")
+        .assert();
+
+    assert.success().stdout("s3 ls\n");
+}

--- a/src/esthri/tests/integration/main.rs
+++ b/src/esthri/tests/integration/main.rs
@@ -1,5 +1,6 @@
 #![cfg_attr(feature = "aggressive_lint", deny(warnings))]
 
+mod cli_test;
 mod download_test;
 mod http_server;
 mod list_object_test;

--- a/src/esthri/tests/integration/sync_test.rs
+++ b/src/esthri/tests/integration/sync_test.rs
@@ -54,10 +54,12 @@ async fn test_sync_down_async() {
 }
 
 #[test]
-fn test_sync_down_fail() {
+fn test_sync_down_without_slash() {
     let s3client = crate::get_s3client();
     let local_directory = "tests/data/";
     let s3_key = "test_folder";
+    let includes: Option<Vec<String>> = Some(vec!["*.txt".to_string()]);
+    let excludes: Option<Vec<String>> = Some(vec!["*".to_string()]);
 
     let source = S3PathParam::new_bucket(crate::TEST_BUCKET, s3_key);
     let destination = S3PathParam::new_local(local_directory);
@@ -66,19 +68,21 @@ fn test_sync_down_fail() {
         s3client.as_ref(),
         source,
         destination,
-        INCLUDE_EMPTY,
-        EXCLUDE_EMPTY,
+        includes.as_deref(),
+        excludes.as_deref(),
         #[cfg(feature = "compression")]
         false,
     );
-    assert!(res.is_err());
+    assert!(res.is_ok());
 }
 
 #[test]
-fn test_sync_up_fail() {
+fn test_sync_up_without_slash() {
     let s3client = crate::get_s3client();
     let local_directory = "tests/data/";
     let s3_key = "test_folder";
+    let includes: Option<Vec<String>> = Some(vec!["*.txt".to_string()]);
+    let excludes: Option<Vec<String>> = Some(vec!["*".to_string()]);
 
     let source = S3PathParam::new_local(local_directory);
     let destination = S3PathParam::new_bucket(crate::TEST_BUCKET, s3_key);
@@ -87,12 +91,12 @@ fn test_sync_up_fail() {
         s3client.as_ref(),
         source,
         destination,
-        INCLUDE_EMPTY,
-        EXCLUDE_EMPTY,
+        includes.as_deref(),
+        excludes.as_deref(),
         #[cfg(feature = "compression")]
         false,
     );
-    assert!(res.is_err());
+    assert!(res.is_ok());
 }
 
 #[test]


### PR DESCRIPTION
Fixes some edge cases with the AWS tool compatibility mode, mostly to do with how directories are handled.

Allows:

- `aws cp s3://bucket/prefix/file /mydir/` -> file is downloaded to `/mydir/file`
- `aws cp /mydir/file s3://bucket/prefix/` -> file is uploaded to `s3://bucket/prefix/file`
- `aws cp sync s3://bucket/prefix /mydir` -> files within prefix are synced to `/mydir` (if either paths are to files then this will still fail, but allows flexibility in not having the trailing slash)

These are all to allow SITL functionality to continue to function as before when using the esthri compatibility mode.

Also adds some integration tests to ensure that the CLI program works as expected in the aws compatibility mode.