### PR TITLE
File browser: Allow display of compressed files [DEVINFRA-513]

### DIFF
--- a/src/esthri/src/http_server.rs
+++ b/src/esthri/src/http_server.rs
@@ -526,7 +526,7 @@ fn format_title(bucket: &str, path: &str) -> Markup {
                         (component)
                     }
 
-                    (format_archive_download_button(".", component))
+                    (format_archive_download_button(".?archive=true",&format!("Download tgz archive of {}", component)))
                 } @else {
                     a href=("../".repeat(path_length - 1 - i)) {
                         (component)

--- a/src/esthri/src/http_server.rs
+++ b/src/esthri/src/http_server.rs
@@ -482,6 +482,9 @@ fn format_object_link(path: &str) -> Markup {
                 a href=(format!("{}?from_gz_compressed=true", uncompressed_path)) {
                     (uncompressed_path)
                 }
+                span style="color: lightgrey" {
+                    " .gz"
+                }
             } @else {
                 a href=(path) {
                     (path)

--- a/src/esthri/src/http_server.rs
+++ b/src/esthri/src/http_server.rs
@@ -483,7 +483,7 @@ fn format_object_link(path: &str) -> Markup {
                     (uncompressed_path)
                 }
                 span style="color: lightgrey" {
-                    " .gz"
+                    ".gz"
                 }
             } @else {
                 a href=(path) {

--- a/src/esthri/src/http_server.rs
+++ b/src/esthri/src/http_server.rs
@@ -21,6 +21,7 @@ use std::sync::{
 };
 use std::{io, io::ErrorKind};
 
+use hyper::header::CONTENT_ENCODING;
 use log::*;
 
 use warp::http;
@@ -36,7 +37,7 @@ use once_cell::sync::OnceCell;
 
 use mime_guess::mime::{APPLICATION_OCTET_STREAM, TEXT_HTML_UTF_8};
 
-use crate::rusoto::*;
+use crate::{rusoto::*, ObjectInfo};
 
 // Import all extensions that allow converting between futures-rs and tokio types
 use tokio_util::compat::*;
@@ -74,12 +75,14 @@ use serde_derive::{Deserialize, Serialize};
 
 const ARCHIVE_ENTRY_MODE: u32 = 0o0644;
 const LAST_MODIFIED_TIME_FMT: &str = "%a, %d %b %Y %H:%M:%S GMT";
+const COMPRESSION_SUFFIX: &str = ".gz";
 
 #[derive(Deserialize)]
 struct DownloadParams {
     archive: Option<bool>,
     archive_name: Option<String>,
     prefixes: Option<S3PrefixList>,
+    from_gz_compressed: Option<bool>,
 }
 
 #[derive(Debug)]
@@ -443,31 +446,60 @@ fn get_stripped_path<'a>(base: &str, path: &'a str) -> &'a str {
     path.strip_prefix(base).unwrap()
 }
 
-fn format_archive_download_button(path: &str, tooltip_label: &str) -> Markup {
+fn format_archive_download_button(path: &str, tooltip: &str) -> Markup {
     html! {
-        a class="btn btn-primary btn-sm" role="button" href=(format!("{}?archive=true", path))
-            title=(format!("Download tgz archive of {}", tooltip_label)) {
+        a class="btn btn-primary btn-sm" role="button" href=(path)
+            title=(tooltip) {
             span class="fa fa-file-archive fa-lg" { }
+        }
+    }
+}
+
+fn format_prefix_link(prefix: &str) -> Markup {
+    html! {
+        div {
+            i class="far fa-folder fa-fw pe-4" { }
+            a href=(prefix) {
+                (prefix)
+            }
+        }
+        (format_archive_download_button(&format!("{}?archive=true", prefix), &format!("Download tgz archive of {}", prefix)))
+    }
+}
+
+#[allow(clippy::branches_sharing_code)]
+fn format_object_link(path: &str) -> Markup {
+    let is_gzip_compressed = path.ends_with(COMPRESSION_SUFFIX);
+    let uncompressed_path = match is_gzip_compressed {
+        true => path.strip_suffix(COMPRESSION_SUFFIX).unwrap(),
+        false => path,
+    };
+
+    html! {
+        div {
+            i class="far fa-file fa-fw pe-4" { }
+            @if is_gzip_compressed {
+                a href=(format!("{}?from_gz_compressed=true", uncompressed_path)) {
+                    (uncompressed_path)
+                }
+            } @else {
+                a href=(path) {
+                    (path)
+                }
+            }
+        }
+        @if is_gzip_compressed {
+            (format_archive_download_button(path, &format!("Download {}" ,path)))
         }
     }
 }
 
 fn format_bucket_item(path: &str, archive: bool) -> Markup {
     html! {
-        div {
-            @if archive {
-                i class="far fa-folder fa-fw pe-4" { }
-            } @else {
-                i class="far fa-file fa-fw pe-4" { }
-            }
-
-            a href=(path) {
-                (path)
-            }
-        }
-
         @if archive {
-            (format_archive_download_button(path, path))
+            (format_prefix_link(path))
+        } @else {
+            (format_object_link(path))
         }
     }
 }
@@ -577,26 +609,51 @@ async fn create_item_stream(
     }
 }
 
-async fn item_pre_response<'a, T: S3 + Send>(
+async fn get_obj_info<'a, T: S3 + Send>(
     s3: &T,
-    bucket: String,
-    path: String,
-    if_none_match: Option<String>,
-    mut resp_builder: response::Builder,
-) -> Result<(response::Builder, Option<(String, String)>), warp::Rejection> {
-    let obj_info = match head_object(s3, &bucket, &path).await {
+    bucket: &str,
+    path: &str,
+) -> Result<ObjectInfo, warp::Rejection> {
+    match head_object(s3, &bucket, &path).await {
         Ok(obj_info) => {
             if let Some(obj_info) = obj_info {
-                obj_info
+                Ok(obj_info)
             } else {
-                return Err(warp::reject::not_found());
+                Err(warp::reject::not_found())
             }
         }
         Err(err) => {
             let message = format!("error listing item: {}", err);
-            return EsthriRejection::warp_result(message);
+            EsthriRejection::warp_result(message)
         }
-    };
+    }
+}
+
+async fn item_pre_response<'a, T: S3 + Send>(
+    s3: &T,
+    bucket: String,
+    path: String,
+    serve_compressed: bool,
+    if_none_match: Option<String>,
+    mut resp_builder: response::Builder,
+) -> Result<(response::Builder, Option<(String, String)>), warp::Rejection> {
+    let (obj_info, path, serve_compressed) = match get_obj_info(s3, &bucket, &path).await {
+        Ok(info) => Ok((info, path, serve_compressed)),
+        Err(error) => {
+            if error.is_not_found() && !path.ends_with(COMPRESSION_SUFFIX) {
+                // Allows automatic fallback to the compressed version, if the
+                // non compressed version is requested. This is useful for users
+                // who might be using esthri in 'transparent compression mode',
+                // where they want to embed links between files and are unaware
+                // the files they have uploaded have been compressed.
+                let gz_path = format!("{}{}", &path, COMPRESSION_SUFFIX);
+                Ok((get_obj_info(s3, &bucket, &gz_path).await?, gz_path, true))
+            } else {
+                Err(error)
+            }
+        }
+    }?;
+
     let not_modified = if_none_match
         .map(|etag| etag.strip_prefix("W/").map(String::from).unwrap_or(etag))
         .map(|etag| etag == obj_info.e_tag)
@@ -616,7 +673,18 @@ async fn item_pre_response<'a, T: S3 + Send>(
                 .format(LAST_MODIFIED_TIME_FMT)
                 .to_string(),
         );
-        let mime = mime_guess::from_path(&path);
+
+        if serve_compressed {
+            resp_builder = resp_builder.header(CONTENT_ENCODING, "gzip");
+        }
+
+        let content_path = if serve_compressed {
+            path.strip_suffix(COMPRESSION_SUFFIX).unwrap_or(&path)
+        } else {
+            &path
+        };
+
+        let mime = mime_guess::from_path(content_path);
         let mime = mime.first();
         if let Some(mime) = mime {
             resp_builder = resp_builder.header(CONTENT_TYPE, mime.essence_str());
@@ -737,8 +805,23 @@ async fn download(
             Err(e) => (Some(Body::from(e.to_string())), header),
         }
     } else {
-        let (resp_builder, create_stream) =
-            item_pre_response(&s3, bucket, path, if_none_match, resp_builder).await?;
+        let serve_compressed = params.from_gz_compressed.unwrap_or(false);
+
+        let path = if serve_compressed {
+            format!("{}{}", path, COMPRESSION_SUFFIX)
+        } else {
+            path
+        };
+
+        let (resp_builder, create_stream) = item_pre_response(
+            &s3,
+            bucket,
+            path,
+            serve_compressed,
+            if_none_match,
+            resp_builder,
+        )
+        .await?;
         if let Some((bucket, path)) = create_stream {
             let stream = create_item_stream(s3.clone(), bucket, path).await;
             (Some(Body::wrap_stream(stream)), resp_builder)

--- a/src/esthri/tests/data/compressed.html.gz
+++ b/src/esthri/tests/data/compressed.html.gz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:646f000bf889e17840462369c1ff94fe1fff4ee6d39b6198dbbc9028dc046b84
+size 71


### PR DESCRIPTION
Allows the file browser to display gzip compressed files, through
serving them with the content-encoding set to gzip. The way this works
is:

- Files are detected as gzip compressed by searching for the '.gz'
  suffix on the file
- For gzip compressed files, the browser will add links to the 'non
  compressed' (sans .gz) file path with a 'from_gz_compressed' query
  param
- With the 'from_gz_compressed' query param selected, the file browser
  will get the file with gz suffix and serve it, setting the content-type to 
  gzip

Also added is the ability to automatically fall back to serving a .gz
file if the path is not available. This is useful for users of esthri
who have uploaded files that have transparently been compressed (and had
a .gz suffix added) so that they can still embed links between files.

In terms of UI, the archive buttons is now show on gzip uploaded files. Clicking on the button downloads the gzip file directly.

![image](https://user-images.githubusercontent.com/3880246/140825171-1316c863-5e0a-412e-8d89-3c9b1851fd03.png)