### PR TITLE
File browser: Make startup log link clickable

### DIFF
--- a/src/esthri/src/http_server.rs
+++ b/src/esthri/src/http_server.rs
@@ -269,7 +269,7 @@ pub async fn run(
         debug!("got shutdown signal, waiting for all open connections to complete...");
     });
 
-    info!("listening on: {}...", addr);
+    info!("listening on: http://{}...", addr);
     let _ = tokio::task::spawn(server).await;
 
     info!("shutting down...");


### PR DESCRIPTION
Tiny change to make the info message printed to the terminal clickable.
Helpful for people who lose track of their open tabs!