### PR TITLE
Release: Fix readme not displaying on crates.io

### DIFF
--- a/src/esthri/Cargo.toml
+++ b/src/esthri/Cargo.toml
@@ -12,6 +12,7 @@ edition = "2018"
 license = "MIT"
 repository = "https://github.com/swift-nav/esthri/"
 homepage = "https://github.com/swift-nav/esthri/"
+readme = "../README.md"
 categories = ["command-line-utilities"]
 keywords = ["aws", "s3"]
 exclude = ["tests/"]


### PR DESCRIPTION
https://crates.io/crates/esthri currently doesn't show the esthri
readme. This seems to be because the readme is a level up from where the
package is defined, which should hopefully be fixed by specifying it
exactly.