### PR TITLE
sync: Add a "compressed down" option [DEVINFRA-589]

### DIFF
--- a/src/esthri/src/compression.rs
+++ b/src/esthri/src/compression.rs
@@ -81,6 +81,16 @@ pub(crate) async fn compress_and_replace(path: impl AsRef<Path>) -> Result<PathB
         let (_temp_file, temp_path) = temp_file.keep()?;
         temp_path
     };
+    let file_gz = path_to_compressed_path(path);
+    debug!("renaming {} to {}", path.display(), file_gz.display());
+    fs::rename(temp_path, &file_gz)?;
+    let permissions = path.metadata()?.permissions();
+    fs::set_permissions(&file_gz, permissions)?;
+    fs::remove_file(path)?;
+    Ok(file_gz)
+}
+
+pub(crate) fn path_to_compressed_path(path: &Path) -> PathBuf {
     let file_gz = path
         .extension()
         .map(OsString::from)
@@ -89,10 +99,40 @@ pub(crate) async fn compress_and_replace(path: impl AsRef<Path>) -> Result<PathB
             path.to_path_buf().with_extension(ext)
         })
         .unwrap_or_else(|| path.to_path_buf().with_extension("gz"));
-    debug!("renaming {} to {}", path.display(), file_gz.display());
-    fs::rename(temp_path, &file_gz)?;
-    let permissions = path.metadata()?.permissions();
-    fs::set_permissions(&file_gz, permissions)?;
-    fs::remove_file(path)?;
-    Ok(file_gz)
+    file_gz
+}
+
+pub(crate) fn compressed_path_to_path(path: &Path) -> PathBuf {
+    let mut pathbuf = path.to_path_buf();
+    let ext = path.extension();
+
+    if let Some(ext) = ext {
+        if ext == "gz" {
+            let filename = path.file_name().unwrap();
+            pathbuf.set_file_name(filename.to_string_lossy().strip_suffix(".gz").unwrap());
+        }
+    }
+
+    pathbuf
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_compressed_path_to_path() {
+        assert_eq!(
+            Path::new("myfile.tar"),
+            compressed_path_to_path(Path::new("myfile.tar.gz"))
+        );
+        assert_eq!(
+            Path::new("myfile.tar"),
+            compressed_path_to_path(Path::new("myfile.tar"))
+        );
+        assert_eq!(
+            Path::new("/tmp/path/to/mycode.rs"),
+            compressed_path_to_path(Path::new("/tmp/path/to/mycode.rs.gz"))
+        );
+    }
 }

--- a/src/esthri/src/errors.rs
+++ b/src/esthri/src/errors.rs
@@ -109,7 +109,7 @@ pub enum Error {
     #[error(transparent)]
     JoinError(#[from] JoinError),
 
-    #[error("sync: compression is only valid for upload")]
+    #[error("sync: compression is not valid for bucket to bucket transfers")]
     InvalidSyncCompress,
 
     #[cfg(feature = "compression")]

--- a/src/esthri/src/errors.rs
+++ b/src/esthri/src/errors.rs
@@ -128,6 +128,10 @@ pub enum Error {
 
     #[error("Could not parse S3 filename")]
     CouldNotParseS3Filename,
+
+    #[cfg(feature = "compression")]
+    #[error("File is not gzip compressed")]
+    FileNotCompressed,
 }
 
 impl From<std::convert::Infallible> for Error {

--- a/src/esthri/src/main.rs
+++ b/src/esthri/src/main.rs
@@ -363,7 +363,7 @@ async fn dispatch_esthri_cli(cmd: EsthriCommand, s3: &S3Client) -> Result<()> {
             {
                 compress = matches!(cmd, Sync { compress: true, .. });
 
-                if compress && !(source.is_local() && destination.is_bucket()) {
+                if compress && (source.is_bucket() && destination.is_bucket()) {
                     return Err(errors::Error::InvalidSyncCompress);
                 }
             }

--- a/src/esthri/src/ops/sync.rs
+++ b/src/esthri/src/ops/sync.rs
@@ -240,7 +240,6 @@ where
         {
             use crate::compression::{
                 compress_and_replace, compress_to_tempfile, compressed_path_to_path,
-                path_to_compressed_path,
             };
 
             let (path, local_etag) = match compressed {
@@ -273,7 +272,7 @@ where
                             let (temp_compressed, _) =
                                 compress_to_tempfile(&uncompressed_path).await?;
                             let local_etag = compute_etag(&temp_compressed).await;
-                            (path_to_compressed_path(&path), local_etag)
+                            (path, local_etag)
                         }
                     } else {
                         let local_etag = compute_etag(&path).await;

--- a/src/esthri/src/ops/sync.rs
+++ b/src/esthri/src/ops/sync.rs
@@ -108,7 +108,16 @@ where
                 key
             );
 
-            sync_remote_to_local(s3, &bucket, &key, &path, &glob_includes, &glob_excludes).await?;
+            sync_remote_to_local(
+                s3,
+                &bucket,
+                &key,
+                &path,
+                &glob_includes,
+                &glob_excludes,
+                compressed,
+            )
+            .await?;
         }
         (
             S3PathParam::Bucket {
@@ -209,9 +218,16 @@ fn create_dirent_stream<'a>(
     }
 }
 
+#[derive(Debug, Clone, Copy)]
+enum SyncCompressionDirection {
+    None,
+    Up,
+    Down,
+}
+
 fn map_paths_to_etags<StreamT>(
     input_stream: StreamT,
-    compressed: bool,
+    compressed: SyncCompressionDirection,
 ) -> impl Stream<Item = impl Future<Output = MapEtagResult>>
 where
     StreamT: Stream<Item = Result<(String, Option<ListingMetadata>)>>,
@@ -222,26 +238,55 @@ where
         let path = PathBuf::from_str(&path)?;
         #[cfg(feature = "compression")]
         {
-            use crate::compression::compress_and_replace;
-            let (path, local_etag) = if compressed {
-                if path.extension().map(|e| e == "gz").unwrap_or(false) {
-                    let local_etag = compute_etag(&path).await;
-                    (path, local_etag)
-                } else {
-                    info!("compressing and replacing: {}", path.display());
-                    let path = compress_and_replace(path).await?;
+            use crate::compression::{
+                compress_and_replace, compress_to_tempfile, compressed_path_to_path,
+                path_to_compressed_path,
+            };
+
+            let (path, local_etag) = match compressed {
+                SyncCompressionDirection::None => {
                     let local_etag = compute_etag(&path).await;
                     (path, local_etag)
                 }
-            } else {
-                let local_etag = compute_etag(&path).await;
-                (path, local_etag)
+                SyncCompressionDirection::Up => {
+                    if path.extension().map(|e| e == "gz").unwrap_or(false) {
+                        let local_etag = compute_etag(&path).await;
+                        (path, local_etag)
+                    } else {
+                        info!("compressing and replacing: {}", path.display());
+                        let path = compress_and_replace(path).await?;
+                        let local_etag = compute_etag(&path).await;
+                        (path, local_etag)
+                    }
+                }
+                SyncCompressionDirection::Down => {
+                    if path.extension().map(|e| e == "gz").unwrap_or(false) {
+                        let uncompressed_path = compressed_path_to_path(&path);
+
+                        if !uncompressed_path.exists() {
+                            (path, Err(Error::ETagNotPresent))
+                        } else {
+                            // Check if we already have a copy locally
+                            // of the uncompressed file by recompressing
+                            // the local file to see if it matches with
+                            // the compressed version
+                            let (temp_compressed, _) =
+                                compress_to_tempfile(&uncompressed_path).await?;
+                            let local_etag = compute_etag(&temp_compressed).await;
+                            (path_to_compressed_path(&path), local_etag)
+                        }
+                    } else {
+                        let local_etag = compute_etag(&path).await;
+                        (path, local_etag)
+                    }
+                }
             };
+
             Ok((path, local_etag, metadata))
         }
         #[cfg(not(feature = "compression"))]
         {
-            if !compressed {
+            if matches!(compressed, SyncCompressionDirection::None) {
                 let local_etag = compute_etag(&path).await;
                 Ok((path, local_etag, metadata))
             } else {
@@ -328,7 +373,13 @@ where
     let directory = directory.as_ref();
     let task_count = Config::global().concurrent_sync_tasks();
     let dirent_stream = create_dirent_stream(directory, glob_includes, glob_excludes);
-    let etag_stream = map_paths_to_etags(dirent_stream, compressed).buffer_unordered(task_count);
+    let compression = if compressed {
+        SyncCompressionDirection::Up
+    } else {
+        SyncCompressionDirection::None
+    };
+
+    let etag_stream = map_paths_to_etags(dirent_stream, compression).buffer_unordered(task_count);
     let sync_tasks = local_to_remote_sync_tasks(
         s3.clone(),
         bucket.into(),
@@ -470,6 +521,7 @@ fn remote_to_local_sync_tasks<ClientT, StreamT>(
     key: String,
     directory: PathBuf,
     input_stream: StreamT,
+    decompress: bool,
 ) -> impl Stream<Item = impl Future<Output = Result<()>>>
 where
     ClientT: S3 + Sync + Send + Clone,
@@ -483,38 +535,57 @@ where
                 bucket.clone(),
                 key.clone(),
                 directory.clone(),
+                decompress,
                 entry.unwrap(),
             )
         })
-        .map(|(s3, bucket, key, directory, entry)| async move {
-            let (path, local_etag, metadata) = entry;
-            let metadata = metadata.unwrap();
-            match local_etag {
-                Ok(local_etag) => {
-                    if local_etag != metadata.e_tag {
-                        debug!(
-                            "etag mismatch: {}, local etag={}, remote etag={}",
-                            path.display(),
-                            local_etag,
-                            metadata.e_tag
-                        );
-                        download_with_dir(&s3, &bucket, &key, &metadata.s3_suffix, &directory)
+        .map(
+            |(s3, bucket, key, directory, decompress, entry)| async move {
+                let (path, local_etag, metadata) = entry;
+                let metadata = metadata.unwrap();
+                match local_etag {
+                    Ok(local_etag) => {
+                        if local_etag != metadata.e_tag {
+                            debug!(
+                                "etag mismatch: {}, local etag={}, remote etag={}",
+                                path.display(),
+                                local_etag,
+                                metadata.e_tag
+                            );
+                            download_with_dir(
+                                &s3,
+                                &bucket,
+                                &key,
+                                &metadata.s3_suffix,
+                                &directory,
+                                decompress,
+                            )
                             .await?;
+                        } else {
+                            debug!("etag match: {}", path.display());
+                        }
                     }
+                    Err(err) => match err {
+                        Error::ETagNotPresent => {
+                            debug!("file did not exist locally: {}", path.display());
+                            download_with_dir(
+                                &s3,
+                                &bucket,
+                                &key,
+                                &metadata.s3_suffix,
+                                &directory,
+                                decompress,
+                            )
+                            .await?;
+                        }
+                        _ => {
+                            warn!("s3 etag error: {}", err);
+                        }
+                    },
                 }
-                Err(err) => match err {
-                    Error::ETagNotPresent => {
-                        debug!("file did not exist locally: {}", path.display());
-                        download_with_dir(&s3, &bucket, &key, &metadata.s3_suffix, &directory)
-                            .await?;
-                    }
-                    _ => {
-                        warn!("s3 etag error: {}", err);
-                    }
-                },
-            }
-            Ok(())
-        })
+                Ok(())
+            },
+        )
 }
 
 async fn sync_remote_to_local<T>(
@@ -524,6 +595,7 @@ async fn sync_remote_to_local<T>(
     directory: impl AsRef<Path>,
     glob_includes: &[Pattern],
     glob_excludes: &[Pattern],
+    decompress: bool,
 ) -> Result<()>
 where
     T: S3 + Sync + Send + Clone,
@@ -532,13 +604,21 @@ where
     let task_count = Config::global().concurrent_sync_tasks();
     let object_listing =
         flattened_object_listing(s3, bucket, key, directory, glob_includes, glob_excludes);
-    let etag_stream = map_paths_to_etags(object_listing, false).buffer_unordered(task_count);
+
+    let compression = if decompress {
+        SyncCompressionDirection::Down
+    } else {
+        SyncCompressionDirection::None
+    };
+
+    let etag_stream = map_paths_to_etags(object_listing, compression).buffer_unordered(task_count);
     let sync_tasks = remote_to_local_sync_tasks(
         s3.clone(),
         bucket.into(),
         key.into(),
         directory.into(),
         etag_stream,
+        decompress,
     );
 
     sync_tasks

--- a/src/esthri/src/ops/sync.rs
+++ b/src/esthri/src/ops/sync.rs
@@ -260,7 +260,8 @@ where
                 }
                 SyncCompressionDirection::Down => {
                     if path.extension().map(|e| e == "gz").unwrap_or(false) {
-                        let uncompressed_path = compressed_path_to_path(&path);
+                        let uncompressed_path =
+                            compressed_path_to_path(&path).expect("Path should be compressed");
 
                         if !uncompressed_path.exists() {
                             (path, Err(Error::ETagNotPresent))

--- a/src/esthri/tests/integration/sync_test.rs
+++ b/src/esthri/tests/integration/sync_test.rs
@@ -250,33 +250,22 @@ async fn test_sync_across() {
 }
 
 #[cfg(feature = "compression")]
-#[test]
-fn test_sync_up_compressed() {
-    let s3client = crate::get_s3client();
+fn sync_test_files_up_compressed(s3client: &rusoto_s3::S3Client, s3_key: &str) -> String {
     let data_dir = "tests/data/sync_up/";
     let temp_data_dir = "sync_up_compressed/";
-    let s3_key = "test_sync_up_compressed/";
-
     let old_cwd = std::env::current_dir().unwrap();
     let data_dir_fp = old_cwd.join(data_dir);
-
     eprintln!("{:?}", old_cwd);
-
     let tmp_dir = crate::EphemeralTempDir::pushd();
     let temp_data_dir_fp = tmp_dir.temp_dir.path().join(temp_data_dir);
-
     eprintln!("temp_data_dir: {:?}", temp_data_dir_fp);
-
     let mut opts = fs_extra::dir::CopyOptions::new();
     opts.copy_inside = true;
-
     fs_extra::dir::copy(data_dir_fp, temp_data_dir, &opts).unwrap();
-
     let source = S3PathParam::new_local(temp_data_dir);
     let destination = S3PathParam::new_bucket(crate::TEST_BUCKET, s3_key);
-
     let res = blocking::sync(
-        s3client.as_ref(),
+        s3client,
         source,
         destination,
         INCLUDE_EMPTY,
@@ -284,6 +273,14 @@ fn test_sync_up_compressed() {
         true,
     );
     assert!(res.is_ok());
+    s3_key.to_string()
+}
+
+#[cfg(feature = "compression")]
+#[test]
+fn test_sync_up_compressed() {
+    let s3client = crate::get_s3client();
+    let s3_key = sync_test_files_up_compressed(s3client.as_ref(), "test_sync_up_compressed/");
 
     let key_hash_pairs = [
         KeyHashPair("1-one.data.gz", "\"276ebe187bb53cb68e484e8c0c0fef68\""),
@@ -300,4 +297,83 @@ fn test_sync_up_compressed() {
         assert!(res.is_some(), "s3 etag returned was nil for: {}", key);
         assert_eq!(res.unwrap().e_tag, key_hash_pair.1, "invalid hash: {}", key);
     }
+}
+
+/// Test downloading files that were synced up with compression enabled
+/// These should download as the original, uncompressed file
+#[cfg(feature = "compression")]
+#[test]
+fn test_sync_down_compressed() {
+    let s3client = crate::get_s3client();
+    let s3_key = "test_sync_down_compressed/";
+
+    sync_test_files_up_compressed(s3client.as_ref(), s3_key);
+
+    let local_directory = "tests/data/sync_down/d";
+    let sync_dir_meta = fs::metadata(local_directory);
+
+    if let Ok(sync_dir_meta) = sync_dir_meta {
+        assert!(sync_dir_meta.is_dir());
+        assert!(fs::remove_dir_all(local_directory).is_ok());
+    }
+    let destination = S3PathParam::new_local(local_directory);
+
+    let res = blocking::sync(
+        s3client.as_ref(),
+        S3PathParam::new_bucket(crate::TEST_BUCKET, s3_key),
+        destination,
+        INCLUDE_EMPTY,
+        EXCLUDE_EMPTY,
+        #[cfg(feature = "compression")]
+        true,
+    );
+    assert!(res.is_ok());
+
+    let key_hash_pairs = [
+        KeyHashPair("1-one.data", "827aa1b392c93cb25d2348bdc9b907b0"),
+        KeyHashPair("2-two.bin", "35500e07a35b413fc5f434397a4c6bfa"),
+        KeyHashPair("3-three.junk", "388f9763d78cecece332459baecb4b85"),
+        KeyHashPair("nested/2MiB.bin", "64a2635e42ef61c69d62feebdbf118d4"),
+    ];
+
+    validate_key_hash_pairs(local_directory, &key_hash_pairs);
+}
+
+/// Test syncing down a mix of compressed and non-compressed files
+#[cfg(feature = "compression")]
+#[test]
+fn test_sync_down_compressed_mixed() {
+    let s3client = crate::get_s3client();
+
+    let local_directory = "tests/data/sync_down/d";
+    let sync_dir_meta = fs::metadata(local_directory);
+
+    if let Ok(sync_dir_meta) = sync_dir_meta {
+        assert!(sync_dir_meta.is_dir());
+        assert!(fs::remove_dir_all(local_directory).is_ok());
+    }
+    let destination = S3PathParam::new_local(local_directory);
+
+    // Test was data populated with the following command:
+    //
+    //     aws s3 cp compressed.html.gz s3://esthri-test/test_sync_down_mixed_compressed/
+    //     aws s3 cp test_file.txt      s3://esthri-test/test_sync_down_mixed_compressed/
+    //
+    let res = blocking::sync(
+        s3client.as_ref(),
+        S3PathParam::new_bucket(crate::TEST_BUCKET, "test_sync_down_mixed_compressed"),
+        destination,
+        INCLUDE_EMPTY,
+        EXCLUDE_EMPTY,
+        #[cfg(feature = "compression")]
+        true,
+    );
+    assert!(res.is_ok());
+
+    let key_hash_pairs = [
+        KeyHashPair("compressed.html", "b4e3f354e8575e2fa5f489ab6078917c"),
+        KeyHashPair("test_file.txt", "8fd41740698064016b7daaddddd3531a"),
+    ];
+
+    validate_key_hash_pairs(local_directory, &key_hash_pairs);
 }


### PR DESCRIPTION
Syncing down (from bucket to local path) with compression enabled will
now automatically decompress any (gzip) compressed files. Any files that
are not already compressed will be synced as normal.

Equality checks between remote and local files (which are needed in
order to stop remotely compressed files from being re-downloaded) are
implemented by recompressing local files before syncing. This will incur
a processing cost to save a bandwidth cost. On my laptop, compressing a
1GB random file takes about 30 seconds:

    sam@sambuntu:/tmp$ head -c 1G /dev/urandom > test.random
    sam@sambuntu:/tmp$ time gzip -k test.random

    real        0m27.098s
    user        0m26.474s
    sys         0m0.513s

For my slow internet speeds, this will be better than syncing the whole
file down each time but the equation may be different depending on the
types of files synced, and processing/bandwidth constraints.

If this method of checking for file equality becomes painful for some
use-cases, one way to improve it might be to maintain a cache of md5sums
of uncompressed files to md5sums of compressed files, perhaps in a local
`.esthri` folder. This way, if a particular directory is being regularly
synced then each uncompressed file would not need to be compressed each
time.