### PR TITLE
Add metadata to files compressed by esthri [DEVINFRA-589]

### DIFF
--- a/src/esthri/src/blocking.rs
+++ b/src/esthri/src/blocking.rs
@@ -71,7 +71,7 @@ where
     T: S3 + Send + Clone,
     R: Read + Send + 'static,
 {
-    super::upload_from_reader(s3, bucket, key, reader, file_size).await
+    super::upload_from_reader(s3, bucket, key, reader, file_size, None).await
 }
 
 #[cfg(feature = "compression")]

--- a/src/esthri/src/compression.rs
+++ b/src/esthri/src/compression.rs
@@ -13,6 +13,7 @@
 #![cfg_attr(feature = "aggressive_lint", deny(warnings))]
 
 use std::{
+    collections::HashMap,
     ffi::OsString,
     path::{Path, PathBuf},
 };
@@ -32,6 +33,15 @@ mod bio {
     pub(super) use std::io::Seek;
     pub(super) use std::io::SeekFrom;
     pub(super) use tempfile::NamedTempFile;
+}
+
+pub(crate) fn compressed_file_metadata() -> HashMap<String, String> {
+    let mut m = HashMap::new();
+    m.insert(
+        "esthri_compress_version".to_string(),
+        env!("CARGO_PKG_VERSION").to_string(),
+    );
+    m
 }
 
 fn rewind_file<T: bio::Seek>(file: &mut T) -> Result<()> {

--- a/src/esthri/src/lib.rs
+++ b/src/esthri/src/lib.rs
@@ -331,10 +331,17 @@ fn process_head_obj_resp(hoo: HeadObjectOutput) -> Result<Option<ObjectInfo>> {
         ));
     };
 
+    let metadata = if let Some(metadata) = hoo.metadata {
+        metadata
+    } else {
+        return Err(Error::HeadObjectUnexpected("no metadata found".into()));
+    };
+
     Ok(Some(ObjectInfo {
         e_tag,
         size,
         last_modified,
+        metadata,
     }))
 }
 

--- a/src/esthri/src/types.rs
+++ b/src/esthri/src/types.rs
@@ -10,6 +10,7 @@
 * WARRANTIES OF MERCHANTABILITY AND/OR FITNESS FOR A PARTICULAR PURPOSE.
 */
 
+use std::collections::HashMap;
 use std::path::{Path, PathBuf};
 use std::result::Result as StdResult;
 
@@ -27,6 +28,7 @@ pub struct ObjectInfo {
     pub e_tag: String,
     pub size: i64,
     pub last_modified: DateTime<Utc>,
+    pub metadata: HashMap<String, String>,
 }
 
 #[derive(Debug, Clone)]

--- a/src/esthri/tests/integration/upload_test.rs
+++ b/src/esthri/tests/integration/upload_test.rs
@@ -16,6 +16,15 @@ fn test_upload() {
 
     let res = blocking::upload(s3client.as_ref(), crate::TEST_BUCKET, &s3_key, &filepath);
     assert!(res.is_ok());
+
+    let res = blocking::head_object(s3client.as_ref(), crate::TEST_BUCKET, &s3_key);
+    let obj_info: Option<ObjectInfo> = res.unwrap();
+    assert!(obj_info.is_some());
+    let obj_info: ObjectInfo = obj_info.unwrap();
+
+    assert_eq!(obj_info.size, 5242880);
+    assert_eq!(obj_info.e_tag, "\"8542c49db935a57bb8c26ec68d39aaea\"");
+    assert!(!obj_info.metadata.contains_key("esthri_compress_version"));
 }
 
 #[cfg(feature = "compression")]
@@ -39,6 +48,10 @@ fn test_upload_compressed() {
 
     assert_eq!(obj_info.size, 3344161);
     assert_eq!(obj_info.e_tag, "\"4a57bdf6ed65bc7e9ed34a4796561f06\"");
+    assert_eq!(
+        obj_info.metadata.get("esthri_compress_version").unwrap(),
+        env!("CARGO_PKG_VERSION")
+    );
 }
 
 #[tokio::test]


### PR DESCRIPTION
Adds metadata to all files that esthri uploads in compressed mode. This
currently isn't used anywhere but may be useful in the future to do
things like:

- Distinguish between files compressed by Esthri and files independently
  compressed (which may be useful for implementing transparent
  compression/decompression)
- The type of compression used by Esthri, which perhaps may change in
  the future in a non-backwards compatible way