### PR TITLE
download: Make directory path if it doesn't exist [DEVINFRA-590]

### DIFF
--- a/src/esthri/Cargo.toml
+++ b/src/esthri/Cargo.toml
@@ -35,6 +35,7 @@ envy = "0.4"
 async-stream = "0.3"
 serde = "1"
 serde_derive = "1"
+tempfile = "3.0"
 
 [dev-dependencies]
 md5 = "0.7"
@@ -53,7 +54,7 @@ path = "src/lib.rs"
 default = [ "rustls", "cli", "http_server", "blocking", "compression",]
 aggressive_lint = []
 blocking = []
-compression = [ "flate2", "tempfile"]
+compression = [ "flate2",]
 http_server = [ "async-tar", "async-compression", "bytes", "futures-util", "mime_guess", "sluice", "sanitize-filename", "tokio-util", "warp", "ctrlc", "anyhow", "maud",]
 nativetls = [ "rusoto_credential", "rusoto_core/native-tls", "rusoto_signature", "rusoto_s3/native-tls", "hyper-tls",]
 rustls = [ "rusoto_credential", "rusoto_core/rustls", "rusoto_signature", "rusoto_s3/rustls", "hyper-rustls",]
@@ -150,10 +151,6 @@ optional = true
 
 [dependencies.flate2]
 version = "1.0"
-optional = true
-
-[dependencies.tempfile]
-version = "3.0"
 optional = true
 
 [dependencies.maud]

--- a/src/esthri/src/errors.rs
+++ b/src/esthri/src/errors.rs
@@ -112,7 +112,6 @@ pub enum Error {
     #[error("sync: compression is not valid for bucket to bucket transfers")]
     InvalidSyncCompress,
 
-    #[cfg(feature = "compression")]
     #[error(transparent)]
     PersistError(#[from] tempfile::PersistError),
 

--- a/src/esthri/src/ops/download.rs
+++ b/src/esthri/src/ops/download.rs
@@ -12,6 +12,7 @@
 
 #![cfg_attr(feature = "aggressive_lint", deny(warnings))]
 
+use std::fs::create_dir_all;
 use std::marker::Unpin;
 use std::path::Path;
 use std::pin::Pin;
@@ -33,6 +34,7 @@ mod bio {
     #[cfg(feature = "compression")]
     pub(super) use std::io::prelude::*;
     pub(super) use std::io::ErrorKind;
+    pub(super) use tempfile::NamedTempFile;
 }
 
 use crate::config::Config;
@@ -419,17 +421,6 @@ where
 {
     let (bucket, key, download_path) = (bucket.as_ref(), key.as_ref(), download_path.as_ref());
 
-    // If we're trying to download into a directory, assemble the path for the user
-    let file = if !download_path.is_dir() {
-        download_path.to_path_buf()
-    } else {
-        let s3filename = key
-            .split('/')
-            .next_back()
-            .ok_or(Error::CouldNotParseS3Filename)?;
-        download_path.join(s3filename)
-    };
-
     let stat = head_object_request(s3, bucket, key).await?;
     let total_size = stat
         .ok_or_else(|| Error::GetObjectInvalidKey(key.into()))?
@@ -465,24 +456,58 @@ where
         }
     }
 
+    let tempfile = bio::NamedTempFile::new()?;
+
     if decompress {
         #[cfg(feature = "compression")]
         {
             let file_output: Box<dyn bio::Write + Send + Sync + Unpin> =
-                Box::new(GzDecoder::new(bio::File::create(file)?));
+                Box::new(GzDecoder::new(bio::File::create(tempfile.path())?));
             let file_output = Arc::new(Mutex::new(file_output));
             let downloader = DownloadCompressed::new(file_output, bucket, key, total_size);
-            run_downloader(s3.clone(), downloader, decompress).await
+            run_downloader(s3.clone(), downloader, decompress).await?;
         }
         #[cfg(not(feature = "compression"))]
         {
             panic!("compression feature not enabled");
         }
     } else {
-        let file_output = bio::File::create(file)?;
-        let downloader = DownloadMultiple::new(file_output, bucket, key, total_size);
-        run_downloader(s3.clone(), downloader, decompress).await
+        let downloader =
+            DownloadMultiple::new(bio::File::create(tempfile.path())?, bucket, key, total_size);
+        run_downloader(s3.clone(), downloader, decompress).await?;
     }
+
+    if !download_path.is_file() && !download_path.is_dir() {
+        // If the specified destination directory doesn't already exist,
+        // see if the directory structure needs to be made
+        let directory_path = if !download_path.to_string_lossy().ends_with('/') {
+            let mut path = download_path.to_path_buf();
+            path.pop();
+            path
+        } else {
+            download_path.to_path_buf()
+        };
+
+        info!("Creating directory path {:?}", &directory_path);
+        create_dir_all(directory_path)?;
+    }
+
+    // If we're trying to download into a directory, assemble the path for the user
+    let save_path = if !download_path.is_dir() {
+        download_path.to_path_buf()
+    } else {
+        let s3filename = key
+            .split('/')
+            .next_back()
+            .ok_or(Error::CouldNotParseS3Filename)?;
+        download_path.join(s3filename)
+    };
+
+    tempfile.persist(&save_path)?;
+
+    info!("File downloaded to {:?}", &save_path);
+
+    Ok(())
 }
 
 async fn download_streaming_range<T>(

--- a/src/esthri/src/ops/download.rs
+++ b/src/esthri/src/ops/download.rs
@@ -472,7 +472,10 @@ where
 
         directory_path
     } else {
-        download_path.to_path_buf()
+        download_path
+            .parent()
+            .expect("must have a parent path")
+            .to_path_buf()
     };
 
     let tempfile = bio::NamedTempFile::new_in(directory_path)?;


### PR DESCRIPTION
Allows esthri to work more like `aws s3`, which will create directories
in a download command if they don't exist.

This also changes downloads to download to a temporary file, so that the
non-existing directories only get created if the download is successful
(which mirrors the aws tool behaviour).