### PR TITLE
aws cp compat: Add fallback to compressed file [DEVINFRA-586]

### DIFF
--- a/src/esthri/src/ops/download.rs
+++ b/src/esthri/src/ops/download.rs
@@ -507,6 +507,16 @@ where
             .split('/')
             .next_back()
             .ok_or(Error::CouldNotParseS3Filename)?;
+
+        let s3filename = if decompress {
+            // The caller hasn't specified a filename to download to
+            // (only a directory). Because we're decompressing, we
+            // should strip the compression suffix if there is one
+            s3filename.strip_suffix(".gz").unwrap_or(s3filename)
+        } else {
+            s3filename
+        };
+
         download_path.join(s3filename)
     };
 

--- a/src/esthri/src/ops/upload.rs
+++ b/src/esthri/src/ops/upload.rs
@@ -109,12 +109,17 @@ where
     let key = if !key.ends_with('/') {
         key.to_string()
     } else {
-        let filename = path.file_name().ok_or(Error::CouldNotParseS3Filename)?;
-        format!(
-            "{}{}",
-            key,
-            filename.to_str().ok_or(Error::CouldNotParseS3Filename)?
-        )
+        let filename = path
+            .file_name()
+            .ok_or(Error::CouldNotParseS3Filename)?
+            .to_str()
+            .ok_or(Error::CouldNotParseS3Filename)?;
+
+        if compressed {
+            format!("{}{}.gz", key, filename)
+        } else {
+            format!("{}{}", key, filename)
+        }
     };
 
     if path.exists() {

--- a/src/esthri/tests/integration/download_test.rs
+++ b/src/esthri/tests/integration/download_test.rs
@@ -92,3 +92,20 @@ fn test_download_decompressed() {
     let etag = blocking::compute_etag(filename).unwrap();
     assert_eq!(etag, "\"6dbb4258fa16030c2daf6f1eac93dddd-8\"");
 }
+
+#[cfg(feature = "compression")]
+#[test]
+fn test_download_decompressed_to_directory() {
+    let s3client = crate::get_s3client();
+    let _tmp_dir = crate::EphemeralTempDir::pushd();
+
+    // Test object `test_download/27-185232-msg.csv.gz` must be prepopulated in the S3 bucket
+    let filename = "27-185232-msg.csv";
+    let s3_key = format!("test_download/{}.gz", filename);
+
+    let res = blocking::download_decompressed(s3client.as_ref(), crate::TEST_BUCKET, &s3_key, ".");
+    assert!(res.is_ok());
+
+    let etag = blocking::compute_etag(filename).unwrap();
+    assert_eq!(etag, "\"6dbb4258fa16030c2daf6f1eac93dddd-8\"");
+}


### PR DESCRIPTION
Adds a fallback to a compressed version of a file (with a '.gz' suffix)
when the AWS compatibility mode is used with compression enabled.

This means that users can use the compatibility mode without realising
it is turned on for eg:

    export ESTHRI_AWS_COMPAT_MODE=1
    export ESTHRI_AWS_COMPAT_MODE_COMPRESSION=1

    aws cp myfile.txt s3://mybucket/ # Will get uploaded as myfile.txt.gz
    aws cp s3://mybucket/myfile.txt . # esthri will fallback to downloading and decompressing to myfile.txt

As part of this, I've also enabled compression mode to work for `aws cp`
commands, in the same way it works for `sync` commands currently.