### PR TITLE
tests: Fix CLI tests being enabled when they shouldn't be

### DIFF
--- a/src/esthri/tests/integration/cli_test.rs
+++ b/src/esthri/tests/integration/cli_test.rs
@@ -122,6 +122,7 @@ fn test_aws_fallthrough_cp_option() {
     assert.success().stdout("s3 ls\n");
 }
 
+#[cfg(feature = "compression")]
 #[test]
 fn test_cp_falls_back_with_compression() {
     let mut cmd = Command::cargo_bin("esthri").unwrap();

--- a/src/esthri/tests/integration/main.rs
+++ b/src/esthri/tests/integration/main.rs
@@ -1,5 +1,6 @@
 #![cfg_attr(feature = "aggressive_lint", deny(warnings))]
 
+#[cfg(feature = "cli")]
 mod cli_test;
 mod download_test;
 mod http_server;


### PR DESCRIPTION
I think this was only working previously because we were getting lucky
in which docker containers were being reused.

The CLI tests (and CLI with compression tests) should only run if the
features they rely on are enabled, which this should fix.