### PR TITLE
aws sync: Align filtering to aws tool [SITL-362]

### DIFF
--- a/src/esthri/src/blocking.rs
+++ b/src/esthri/src/blocking.rs
@@ -15,6 +15,8 @@
 use std::io::prelude::*;
 use std::path::Path;
 
+use crate::ops::sync::GlobFilter;
+
 use super::rusoto::*;
 
 use super::ObjectInfo;
@@ -120,8 +122,7 @@ pub async fn sync<T>(
     s3: &T,
     source: S3PathParam,
     destination: S3PathParam,
-    includes: Option<&[impl AsRef<str>]>,
-    excludes: Option<&[impl AsRef<str>]>,
+    filters: Option<&[GlobFilter]>,
     #[cfg(feature = "compression")] compressed: bool,
 ) -> Result<()>
 where
@@ -131,8 +132,7 @@ where
         s3,
         source,
         destination,
-        includes,
-        excludes,
+        filters,
         #[cfg(feature = "compression")]
         compressed,
     )

--- a/src/esthri/src/lib.rs
+++ b/src/esthri/src/lib.rs
@@ -74,12 +74,11 @@ pub(crate) use ops::download::download_streaming;
 pub use ops::upload::setup_upload_termination_handler;
 pub use ops::upload::{abort_upload, upload, upload_from_reader};
 
-pub use ops::sync::sync;
+pub use ops::sync::{sync, GlobFilter};
 
 pub use ops::copy::copy;
 
-pub const INCLUDE_EMPTY: Option<&[&str]> = None;
-pub const EXCLUDE_EMPTY: Option<&[&str]> = None;
+pub const FILTER_EMPTY: Option<&[GlobFilter]> = None;
 
 const EXPECT_SPAWN_BLOCKING: &str = "spawned task failed";
 

--- a/src/esthri/src/main.rs
+++ b/src/esthri/src/main.rs
@@ -354,7 +354,7 @@ fn globs_to_filter_list(
             .collect();
         let excludes: Vec<GlobFilter> = exclude
             .as_ref()
-            .unwrap()
+            .unwrap_or(&vec![])
             .iter()
             .cloned()
             .map(GlobFilter::Exclude)

--- a/src/esthri/src/main.rs
+++ b/src/esthri/src/main.rs
@@ -364,7 +364,7 @@ fn globs_to_filter_list(
             .chain(args_with_indices(excludes, "exclude", matches))
             .collect();
 
-        filters.sort_by(|a, b| b.0.cmp(&a.0));
+        filters.sort_by(|a, b| a.0.cmp(&b.0).reverse());
 
         let filters: Vec<GlobFilter> = filters.iter().cloned().map(|x| x.1).collect();
 

--- a/src/esthri/src/ops/sync.rs
+++ b/src/esthri/src/ops/sync.rs
@@ -67,7 +67,7 @@ where
     let filters: Vec<GlobFilter> = match glob_filters {
         Some(filters) => {
             let mut filters = filters.to_vec();
-            if filters.iter().any(|x| matches!(x, GlobFilter::Include(_))) {
+            if !filters.iter().any(|x| matches!(x, GlobFilter::Include(_))) {
                 filters.push(GlobFilter::Include(Pattern::new("*")?));
             }
             filters

--- a/src/esthri/tests/integration/cli_test.rs
+++ b/src/esthri/tests/integration/cli_test.rs
@@ -215,3 +215,34 @@ fn test_aws_sync_down_filter_exclude_only() {
     validate_key_hash_pairs(sync_to, &key_hash_pairs);
     assert!(fs::remove_dir_all(sync_to).is_ok());
 }
+
+#[test]
+fn test_aws_sync_down_filter_include_only() {
+    let sync_from = "s3://esthri-test/test_sync_down_default";
+    let local_dir = TempDir::new("esthri_cli").unwrap();
+    let sync_to = local_dir.path().to_str().unwrap();
+    let mut cmd = Command::cargo_bin("esthri").unwrap();
+    let assert = cmd
+        .env("ESTHRI_AWS_COMPAT_MODE", "1")
+        .arg("s3")
+        .arg("sync")
+        .arg(sync_from)
+        .arg(sync_to)
+        .arg("--include")
+        .arg("*.bin")
+        .assert();
+
+    assert.success();
+
+    // This should download everything according to the AWS docs,
+    // because there's no explicit exclude
+    let key_hash_pairs = [
+        KeyHashPair("1-one.data", "827aa1b392c93cb25d2348bdc9b907b0"),
+        KeyHashPair("2-two.bin", "35500e07a35b413fc5f434397a4c6bfa"),
+        KeyHashPair("3-three.junk", "388f9763d78cecece332459baecb4b85"),
+        KeyHashPair("nested/2MiB.bin", "64a2635e42ef61c69d62feebdbf118d4"),
+    ];
+
+    validate_key_hash_pairs(sync_to, &key_hash_pairs);
+    assert!(fs::remove_dir_all(sync_to).is_ok());
+}

--- a/src/esthri/tests/integration/cli_test.rs
+++ b/src/esthri/tests/integration/cli_test.rs
@@ -1,5 +1,5 @@
 use assert_cmd::Command;
-use std::fs;
+use std::{fs, path::Path};
 use tempdir::TempDir;
 
 use crate::{validate_key_hash_pairs, KeyHashPair};
@@ -150,4 +150,68 @@ fn test_cp_falls_back_with_compression() {
             "e8b32017e42f2e727316d68ea72c2832",
         )],
     );
+}
+
+#[test]
+fn test_aws_sync_down_filter() {
+    let sync_from = "s3://esthri-test/test_sync_down_default";
+    let local_dir = TempDir::new("esthri_cli").unwrap();
+    let sync_to = local_dir.path().to_str().unwrap();
+    let mut cmd = Command::cargo_bin("esthri").unwrap();
+    let assert = cmd
+        .env("ESTHRI_AWS_COMPAT_MODE", "1")
+        .arg("s3")
+        .arg("sync")
+        .arg(sync_from)
+        .arg(sync_to)
+        .arg("--exclude")
+        .arg("*")
+        .arg("--include")
+        .arg("*.bin")
+        .assert();
+
+    assert.success();
+
+    // Shouldn't have downloaded files that don't match the filtering
+    assert!(!Path::new(sync_to).join("1-one.data").exists());
+    assert!(!Path::new(sync_to).join("3-three.junk").exists());
+
+    let key_hash_pairs = [
+        KeyHashPair("2-two.bin", "35500e07a35b413fc5f434397a4c6bfa"),
+        KeyHashPair("nested/2MiB.bin", "64a2635e42ef61c69d62feebdbf118d4"),
+    ];
+
+    validate_key_hash_pairs(sync_to, &key_hash_pairs);
+    assert!(fs::remove_dir_all(sync_to).is_ok());
+}
+
+#[test]
+fn test_aws_sync_down_filter_exclude_only() {
+    let sync_from = "s3://esthri-test/test_sync_down_default";
+    let local_dir = TempDir::new("esthri_cli").unwrap();
+    let sync_to = local_dir.path().to_str().unwrap();
+    let mut cmd = Command::cargo_bin("esthri").unwrap();
+    let assert = cmd
+        .env("ESTHRI_AWS_COMPAT_MODE", "1")
+        .arg("s3")
+        .arg("sync")
+        .arg(sync_from)
+        .arg(sync_to)
+        .arg("--exclude")
+        .arg("*.bin")
+        .assert();
+
+    assert.success();
+
+    // Shouldn't have downloaded files that don't match the filtering
+    assert!(!Path::new(sync_to).join("2-two.bin").exists());
+    assert!(!Path::new(sync_to).join("nested/2MiB.bin").exists());
+
+    let key_hash_pairs = [
+        KeyHashPair("1-one.data", "827aa1b392c93cb25d2348bdc9b907b0"),
+        KeyHashPair("3-three.junk", "388f9763d78cecece332459baecb4b85"),
+    ];
+
+    validate_key_hash_pairs(sync_to, &key_hash_pairs);
+    assert!(fs::remove_dir_all(sync_to).is_ok());
 }

--- a/src/esthri/tests/integration/main.rs
+++ b/src/esthri/tests/integration/main.rs
@@ -99,6 +99,10 @@ pub fn validate_key_hash_pairs(local_directory: &str, key_hash_pairs: &[KeyHashP
             path
         );
     }
+
+    // Ensure there aren't any extra unexpected files in the directory
+    let paths = fs::read_dir(local_directory).unwrap();
+    assert_eq!(paths.count(), key_hash_pairs.len());
 }
 
 type DateTime = chrono::DateTime<chrono::Utc>;

--- a/src/esthri/tests/integration/sync_test.rs
+++ b/src/esthri/tests/integration/sync_test.rs
@@ -2,7 +2,8 @@
 
 use std::fs;
 
-use esthri::{blocking, sync, S3PathParam, EXCLUDE_EMPTY, INCLUDE_EMPTY};
+use esthri::{blocking, sync, GlobFilter, S3PathParam, FILTER_EMPTY};
+use glob::Pattern;
 
 use crate::{validate_key_hash_pairs, KeyHashPair};
 
@@ -11,8 +12,11 @@ fn test_sync_down() {
     let s3client = crate::get_s3client();
     let local_directory = "tests/data/";
     let s3_key = "test_folder/";
-    let includes: Option<Vec<String>> = Some(vec!["*.txt".to_string()]);
-    let excludes: Option<Vec<String>> = Some(vec!["*".to_string()]);
+
+    let filters: Option<Vec<GlobFilter>> = Some(vec![
+        GlobFilter::Include(Pattern::new("*.txt").unwrap()),
+        GlobFilter::Exclude(Pattern::new("*").unwrap()),
+    ]);
 
     let source = S3PathParam::new_bucket(crate::TEST_BUCKET, s3_key);
     let destination = S3PathParam::new_local(local_directory);
@@ -21,8 +25,7 @@ fn test_sync_down() {
         s3client.as_ref(),
         source,
         destination,
-        includes.as_deref(),
-        excludes.as_deref(),
+        filters.as_deref(),
         #[cfg(feature = "compression")]
         false,
     );
@@ -34,8 +37,10 @@ async fn test_sync_down_async() {
     let s3client = crate::get_s3client();
     let local_directory = "tests/data/";
     let s3_key = "test_folder/";
-    let includes: Option<Vec<String>> = Some(vec!["*.txt".to_string()]);
-    let excludes: Option<Vec<String>> = Some(vec!["*".to_string()]);
+    let filters: Option<Vec<GlobFilter>> = Some(vec![
+        GlobFilter::Include(Pattern::new("*.txt").unwrap()),
+        GlobFilter::Exclude(Pattern::new("*").unwrap()),
+    ]);
 
     let source = S3PathParam::new_bucket(crate::TEST_BUCKET, s3_key);
     let destination = S3PathParam::new_local(local_directory);
@@ -44,8 +49,7 @@ async fn test_sync_down_async() {
         s3client.as_ref(),
         source,
         destination,
-        includes.as_deref(),
-        excludes.as_deref(),
+        filters.as_deref(),
         #[cfg(feature = "compression")]
         false,
     )
@@ -58,8 +62,10 @@ fn test_sync_down_without_slash() {
     let s3client = crate::get_s3client();
     let local_directory = "tests/data/";
     let s3_key = "test_folder";
-    let includes: Option<Vec<String>> = Some(vec!["*.txt".to_string()]);
-    let excludes: Option<Vec<String>> = Some(vec!["*".to_string()]);
+    let filters: Option<Vec<GlobFilter>> = Some(vec![
+        GlobFilter::Include(Pattern::new("*.txt").unwrap()),
+        GlobFilter::Exclude(Pattern::new("*").unwrap()),
+    ]);
 
     let source = S3PathParam::new_bucket(crate::TEST_BUCKET, s3_key);
     let destination = S3PathParam::new_local(local_directory);
@@ -68,8 +74,7 @@ fn test_sync_down_without_slash() {
         s3client.as_ref(),
         source,
         destination,
-        includes.as_deref(),
-        excludes.as_deref(),
+        filters.as_deref(),
         #[cfg(feature = "compression")]
         false,
     );
@@ -81,8 +86,10 @@ fn test_sync_up_without_slash() {
     let s3client = crate::get_s3client();
     let local_directory = "tests/data/";
     let s3_key = "test_folder";
-    let includes: Option<Vec<String>> = Some(vec!["*.txt".to_string()]);
-    let excludes: Option<Vec<String>> = Some(vec!["*".to_string()]);
+    let filters: Option<Vec<GlobFilter>> = Some(vec![
+        GlobFilter::Include(Pattern::new("*.txt").unwrap()),
+        GlobFilter::Exclude(Pattern::new("*").unwrap()),
+    ]);
 
     let source = S3PathParam::new_local(local_directory);
     let destination = S3PathParam::new_bucket(crate::TEST_BUCKET, s3_key);
@@ -91,8 +98,7 @@ fn test_sync_up_without_slash() {
         s3client.as_ref(),
         source,
         destination,
-        includes.as_deref(),
-        excludes.as_deref(),
+        filters.as_deref(),
         #[cfg(feature = "compression")]
         false,
     );
@@ -104,8 +110,10 @@ fn test_sync_up() {
     let s3client = crate::get_s3client();
     let local_directory = "tests/data/";
     let s3_key = "test_folder/";
-    let includes: Option<Vec<String>> = Some(vec!["*.txt".to_string()]);
-    let excludes: Option<Vec<String>> = Some(vec!["*".to_string()]);
+    let filters: Option<Vec<GlobFilter>> = Some(vec![
+        GlobFilter::Include(Pattern::new("*.txt").unwrap()),
+        GlobFilter::Exclude(Pattern::new("*").unwrap()),
+    ]);
 
     let source = S3PathParam::new_local(local_directory);
     let destination = S3PathParam::new_bucket(crate::TEST_BUCKET, s3_key);
@@ -114,8 +122,7 @@ fn test_sync_up() {
         s3client.as_ref(),
         source,
         destination,
-        includes.as_deref(),
-        excludes.as_deref(),
+        filters.as_deref(),
         #[cfg(feature = "compression")]
         false,
     );
@@ -127,8 +134,10 @@ async fn test_sync_up_async() {
     let s3client = crate::get_s3client();
     let local_directory = "tests/data/";
     let s3_key = "test_folder/";
-    let includes: Option<Vec<String>> = Some(vec!["*.txt".to_string()]);
-    let excludes: Option<Vec<String>> = Some(vec!["*".to_string()]);
+    let filters: Option<Vec<GlobFilter>> = Some(vec![
+        GlobFilter::Include(Pattern::new("*.txt").unwrap()),
+        GlobFilter::Exclude(Pattern::new("*").unwrap()),
+    ]);
 
     let source = S3PathParam::new_local(local_directory);
     let destination = S3PathParam::new_bucket(crate::TEST_BUCKET, s3_key);
@@ -137,8 +146,7 @@ async fn test_sync_up_async() {
         s3client.as_ref(),
         source,
         destination,
-        includes.as_deref(),
-        excludes.as_deref(),
+        filters.as_deref(),
         #[cfg(feature = "compression")]
         false,
     )
@@ -159,8 +167,7 @@ fn test_sync_up_default() {
         s3client.as_ref(),
         source,
         destination,
-        INCLUDE_EMPTY,
-        EXCLUDE_EMPTY,
+        FILTER_EMPTY,
         #[cfg(feature = "compression")]
         false,
     );
@@ -207,8 +214,7 @@ fn test_sync_down_default() {
         s3client.as_ref(),
         source,
         destination,
-        INCLUDE_EMPTY,
-        EXCLUDE_EMPTY,
+        FILTER_EMPTY,
         #[cfg(feature = "compression")]
         false,
     );
@@ -230,8 +236,8 @@ async fn test_sync_across() {
     let source_prefix = "test_sync_folder1/";
     let dest_prefix = "test_sync_folder2/";
 
-    let includes: Option<Vec<String>> = Some(vec!["*.txt".to_string()]);
-    let excludes: Option<Vec<String>> = None;
+    let filters: Option<Vec<GlobFilter>> =
+        Some(vec![GlobFilter::Include(Pattern::new("*.txt").unwrap())]);
 
     let source = S3PathParam::new_bucket(crate::TEST_BUCKET, source_prefix);
     let destination = S3PathParam::new_bucket(crate::TEST_BUCKET, dest_prefix);
@@ -240,8 +246,7 @@ async fn test_sync_across() {
         s3client.as_ref(),
         source,
         destination,
-        includes.as_deref(),
-        excludes.as_deref(),
+        filters.as_deref(),
         #[cfg(feature = "compression")]
         false,
     )
@@ -264,14 +269,7 @@ fn sync_test_files_up_compressed(s3client: &rusoto_s3::S3Client, s3_key: &str) -
     fs_extra::dir::copy(data_dir_fp, temp_data_dir, &opts).unwrap();
     let source = S3PathParam::new_local(temp_data_dir);
     let destination = S3PathParam::new_bucket(crate::TEST_BUCKET, s3_key);
-    let res = blocking::sync(
-        s3client,
-        source,
-        destination,
-        INCLUDE_EMPTY,
-        EXCLUDE_EMPTY,
-        true,
-    );
+    let res = blocking::sync(s3client, source, destination, FILTER_EMPTY, true);
     assert!(res.is_ok());
     s3_key.to_string()
 }
@@ -322,8 +320,7 @@ fn test_sync_down_compressed() {
         s3client.as_ref(),
         S3PathParam::new_bucket(crate::TEST_BUCKET, s3_key),
         destination,
-        INCLUDE_EMPTY,
-        EXCLUDE_EMPTY,
+        FILTER_EMPTY,
         #[cfg(feature = "compression")]
         true,
     );
@@ -363,8 +360,7 @@ fn test_sync_down_compressed_mixed() {
         s3client.as_ref(),
         S3PathParam::new_bucket(crate::TEST_BUCKET, "test_sync_down_mixed_compressed"),
         destination,
-        INCLUDE_EMPTY,
-        EXCLUDE_EMPTY,
+        FILTER_EMPTY,
         #[cfg(feature = "compression")]
         true,
     );


### PR DESCRIPTION
The official `aws` tool's `sync` command implements the `--include` and
`--exclude` filters in a somewhat surprising way, which is different to
how esthri currently handles them in the following two ways:

1. In `aws`, the filters are evaluated from right to left (as they
   appear in the CLI arguments) for each file. The first matching filter
   (either exclude or include) is taken as the decision for that file.
   Currently esthri runs through excludes before includes instead.

2. In `aws`, there is always an implicit `--include *` as the last
   filter. This means `--include` statements are only useful if there is
   a `--exclude` filter. Currently esthri will only select a file if it
   matches an explicit include.

To align the `aws` compatibility mode with the real `aws` tool, this
change makes esthri follow these points by slightly changing the
interface to the `sync` function. API users of this function will now
need to provide a slice of `GlobFilter` enums, where each glob is
specified as either `Include` or `Exclude` and where the order in the
slice determines the order that the filter will be evaluated. Existing
users (just SITL, I think) should be able to retain the same functional
behavior by having this slice be `[exclude filters, include filters]`.

For the second point above, this is implemented at the CLI interface as
to not break existing users of the `sync` API, that might rely on only
explicitly included files being selected.