### PR TITLE
Transparent compression using metadata [DEVINFRA-594] [DEVINFRA-595] [DEVINFRA-596] [DEVINFRA-597]

### DIFF
--- a/Makefile.toml
+++ b/Makefile.toml
@@ -21,7 +21,7 @@ TLS_PROVIDER = "nativetls"
 command = "cargo"
 args = [
         "check",
-        "--features=${TLS_PROVIDER},blocking,cli,compression,http_server",
+        "--features=${TLS_PROVIDER},blocking,cli,http_server",
         "@@remove-empty(BUILD_FLAVOR)",
         "@@remove-empty(TARGET)"
         ]
@@ -31,7 +31,7 @@ cwd = "src/esthri"
 command = "cargo"
 args = [
         "build",
-        "--features=${TLS_PROVIDER},blocking,cli,compression,http_server",
+        "--features=${TLS_PROVIDER},blocking,cli,http_server",
         "--no-default-features",
         "@@remove-empty(BUILD_FLAVOR)",
         "@@remove-empty(TARGET)"
@@ -66,7 +66,7 @@ cwd = "src/esthri"
 command = "cargo"
 args = [
         "test",
-        "--features=${TLS_PROVIDER},blocking,cli,compression,http_server",
+        "--features=${TLS_PROVIDER},blocking,cli,http_server",
         "--no-default-features",
         "@@remove-empty(BUILD_FLAVOR)",
         "--",
@@ -89,4 +89,4 @@ args = [
 [tasks.lint]
 command = "cargo"
 cwd = "src/esthri"
-args = ["clippy", "--no-default-features", "--features=${TLS_PROVIDER},aggressive_lint,blocking,cli,compression,http_server"]
+args = ["clippy", "--no-default-features", "--features=${TLS_PROVIDER},aggressive_lint,blocking,cli,http_server"]

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Extremely simple (memory stable) S3 client that supports get, put, head, list,
 and sync.
 
 ```
-esthri 6.0.1
+esthri 6.3.0
 Simple S3 file transfer utility.
 
 USAGE:
@@ -33,7 +33,7 @@ SUBCOMMANDS:
 The esthri CLI tool additionally provides a AWS CLI compatibility mode where it
 is able to handle `cp` and `sync` operations with an identical CLI interface as
 the `aws s3` tool. Currently, only the basic case is implemented for these
-commands and no no optional arguments are handled.
+commands and only some optional arguments are handled.
 
 To use, the esthri binary must either be:
 
@@ -52,13 +52,20 @@ $ ESTHRI_AWS_COMPAT_MODE=1 esthri s3 help # prints the S3 help text, as generate
 ```
 
 ### Transparent Sync Compression
-For `sync` commands in the AWS compatibility mode, esthri can
-transparently compress files such that they are compressed within S3 but
-not when downloaded. The one drawback of this is that syncing up with
-compression currently causes local files to be compressed.
+esthri can transparently compress files such that they are compressed within S3
+but not on the local filesystem. To enable, either set the
+`ESTHRI_AWS_COMPAT_MODE_COMPRESSION` environment variable or use the
+`--transparent-compression` CLI option. For example:
 
-To enable, either set the `ESTHRI_AWS_COMPAT_MODE_COMPRESSION`
-environment variable or pass the `--compress` CLI option.
+```
+ESTHRI_AWS_COMPAT_MODE=1 esthri s3 sync mydirectory/ s3://esthri-test/myfiles/ --transparent-compression # syncs as normal, however files in S3 are gzipped
+ESTHRI_AWS_COMPAT_MODE=1 esthri s3 sync s3://esthri-test/myfiles/ mynewdirectory/ --transparent-compression # syncs and decompresses files as they are synced down. mydirectory and mynewdirectory will now contain the same files
+```
+
+esthri makes use of S3 metadata to do this transparent compression, storing the
+esthri version number in the metadata of files it has compressed. For this
+reason, the decompression will only work for files that esthri has compressed
+itself.
 
 ## Releasing
 

--- a/src/esthri/Cargo.toml
+++ b/src/esthri/Cargo.toml
@@ -36,11 +36,11 @@ async-stream = "0.3"
 serde = "1"
 serde_derive = "1"
 tempfile = "3.0"
+flate2 = "1.0"
 
 [dev-dependencies]
 md5 = "0.7"
 tar = "0.4"
-flate2 = "1.0"
 tempdir = "0.3"
 backtrace = "0.3"
 fs_extra = "1.2"
@@ -51,10 +51,9 @@ name = "esthri"
 path = "src/lib.rs"
 
 [features]
-default = [ "rustls", "cli", "http_server", "blocking", "compression",]
+default = [ "rustls", "cli", "http_server", "blocking",]
 aggressive_lint = []
 blocking = []
-compression = [ "flate2",]
 http_server = [ "async-tar", "async-compression", "bytes", "futures-util", "mime_guess", "sluice", "sanitize-filename", "tokio-util", "warp", "ctrlc", "anyhow", "maud",]
 nativetls = [ "rusoto_credential", "rusoto_core/native-tls", "rusoto_signature", "rusoto_s3/native-tls", "hyper-tls",]
 rustls = [ "rusoto_credential", "rusoto_core/rustls", "rusoto_signature", "rusoto_s3/rustls", "hyper-rustls",]
@@ -147,10 +146,6 @@ optional = true
 [dependencies.ctrlc]
 version = "3.2"
 features = [ "termination",]
-optional = true
-
-[dependencies.flate2]
-version = "1.0"
 optional = true
 
 [dependencies.maud]

--- a/src/esthri/src/blocking.rs
+++ b/src/esthri/src/blocking.rs
@@ -76,7 +76,6 @@ where
     super::upload_from_reader(s3, bucket, key, reader, file_size, None).await
 }
 
-#[cfg(feature = "compression")]
 #[tokio::main]
 pub async fn upload_compressed<T>(
     s3: &T,
@@ -103,7 +102,6 @@ where
     super::download(s3, bucket, key, file).await
 }
 
-#[cfg(feature = "compression")]
 #[tokio::main]
 pub async fn download_decompressed<T>(
     s3: &T,
@@ -123,20 +121,12 @@ pub async fn sync<T>(
     source: S3PathParam,
     destination: S3PathParam,
     filters: Option<&[GlobFilter]>,
-    #[cfg(feature = "compression")] compressed: bool,
+    compressed: bool,
 ) -> Result<()>
 where
     T: S3 + Sync + Send + Clone,
 {
-    super::sync(
-        s3,
-        source,
-        destination,
-        filters,
-        #[cfg(feature = "compression")]
-        compressed,
-    )
-    .await
+    super::sync(s3, source, destination, filters, compressed).await
 }
 
 #[tokio::main]

--- a/src/esthri/src/blocking.rs
+++ b/src/esthri/src/blocking.rs
@@ -103,7 +103,7 @@ where
 }
 
 #[tokio::main]
-pub async fn download_decompressed<T>(
+pub async fn download_with_transparent_decompression<T>(
     s3: &T,
     bucket: impl AsRef<str>,
     key: impl AsRef<str>,
@@ -112,7 +112,7 @@ pub async fn download_decompressed<T>(
 where
     T: S3 + Sync + Send + Clone,
 {
-    super::download_decompressed(s3, bucket, key, file).await
+    super::download_with_transparent_decompression(s3, bucket, key, file).await
 }
 
 #[tokio::main]
@@ -121,12 +121,12 @@ pub async fn sync<T>(
     source: S3PathParam,
     destination: S3PathParam,
     filters: Option<&[GlobFilter]>,
-    compressed: bool,
+    transparent_compression: bool,
 ) -> Result<()>
 where
     T: S3 + Sync + Send + Clone,
 {
-    super::sync(s3, source, destination, filters, compressed).await
+    super::sync(s3, source, destination, filters, transparent_compression).await
 }
 
 #[tokio::main]

--- a/src/esthri/src/config.rs
+++ b/src/esthri/src/config.rs
@@ -30,7 +30,6 @@ pub const DOWNLOAD_BUFFER_SIZE: usize = 8 * 1024 * 1024;
 pub const CONCURRENT_DOWNLOADER_TASKS: u16 = 32;
 /// The default number of concurrent tasks run when receiving compressed data
 /// from S3.  Each task represents a connection to S3.
-
 pub const CONCURRENT_COMPRESSED_DOWNLOADER_TASKS: u16 = 2;
 /// The default number of concurrent tasks run when writing download data to disk.
 pub const CONCURRENT_WRITER_TASKS: u16 = 64;
@@ -48,7 +47,6 @@ pub struct Config {
     download_buffer_size: DownloadBufferSize,
     #[serde(default)]
     concurrent_downloader_tasks: ConcurrentDownloaderTasks,
-
     #[serde(default)]
     concurrent_compressed_downloader_tasks: ConcurrentCompressedDownloaderTasks,
     #[serde(default)]
@@ -95,7 +93,6 @@ impl Default for ConcurrentDownloaderTasks {
 
 /// Wrapper type for [CONCURRENT_COMPRESSED_DOWNLOADER_TASKS] which allows
 /// [Config::concurrent_compressed_downloader_tasks()] to bind a default value.
-
 #[derive(Deserialize)]
 #[serde(transparent)]
 struct ConcurrentCompressedDownloaderTasks(u16);
@@ -191,7 +188,6 @@ impl Config {
 
     /// The number of concurrent tasks run when receiving compressed data from S3.  Each task
     /// represents a connection to S3.  Defaults to [CONCURRENT_COMPRESSED_DOWNLOADER_TASKS].
-
     pub fn concurrent_compressed_downloader_tasks(&self) -> usize {
         self.concurrent_compressed_downloader_tasks.0 as usize
     }

--- a/src/esthri/src/config.rs
+++ b/src/esthri/src/config.rs
@@ -30,7 +30,7 @@ pub const DOWNLOAD_BUFFER_SIZE: usize = 8 * 1024 * 1024;
 pub const CONCURRENT_DOWNLOADER_TASKS: u16 = 32;
 /// The default number of concurrent tasks run when receiving compressed data
 /// from S3.  Each task represents a connection to S3.
-#[cfg(feature = "compression")]
+
 pub const CONCURRENT_COMPRESSED_DOWNLOADER_TASKS: u16 = 2;
 /// The default number of concurrent tasks run when writing download data to disk.
 pub const CONCURRENT_WRITER_TASKS: u16 = 64;
@@ -48,7 +48,7 @@ pub struct Config {
     download_buffer_size: DownloadBufferSize,
     #[serde(default)]
     concurrent_downloader_tasks: ConcurrentDownloaderTasks,
-    #[cfg(feature = "compression")]
+
     #[serde(default)]
     concurrent_compressed_downloader_tasks: ConcurrentCompressedDownloaderTasks,
     #[serde(default)]
@@ -95,12 +95,11 @@ impl Default for ConcurrentDownloaderTasks {
 
 /// Wrapper type for [CONCURRENT_COMPRESSED_DOWNLOADER_TASKS] which allows
 /// [Config::concurrent_compressed_downloader_tasks()] to bind a default value.
-#[cfg(feature = "compression")]
+
 #[derive(Deserialize)]
 #[serde(transparent)]
 struct ConcurrentCompressedDownloaderTasks(u16);
 
-#[cfg(feature = "compression")]
 impl Default for ConcurrentCompressedDownloaderTasks {
     fn default() -> Self {
         ConcurrentCompressedDownloaderTasks(CONCURRENT_COMPRESSED_DOWNLOADER_TASKS)
@@ -192,7 +191,7 @@ impl Config {
 
     /// The number of concurrent tasks run when receiving compressed data from S3.  Each task
     /// represents a connection to S3.  Defaults to [CONCURRENT_COMPRESSED_DOWNLOADER_TASKS].
-    #[cfg(feature = "compression")]
+
     pub fn concurrent_compressed_downloader_tasks(&self) -> usize {
         self.concurrent_compressed_downloader_tasks.0 as usize
     }

--- a/src/esthri/src/errors.rs
+++ b/src/esthri/src/errors.rs
@@ -128,7 +128,6 @@ pub enum Error {
     #[error("Could not parse S3 filename")]
     CouldNotParseS3Filename,
 
-    #[cfg(feature = "compression")]
     #[error("File is not gzip compressed")]
     FileNotCompressed,
 }

--- a/src/esthri/src/http_server.rs
+++ b/src/esthri/src/http_server.rs
@@ -12,6 +12,7 @@
 
 #![cfg_attr(feature = "aggressive_lint", deny(warnings))]
 
+use std::borrow::Cow;
 use std::cell::Cell;
 use std::convert::Infallible;
 use std::net::SocketAddr;
@@ -349,14 +350,14 @@ async fn stream_object_to_archive<T: S3 + Send + Clone>(
     // hopefully make dealing with (transparently) compressed files less
     // confusing
     let path = if obj_info.is_esthri_compressed() {
-        format!("{}.gz", path)
+        Cow::Owned(format!("{}.gz", path))
     } else {
-        path.to_string()
+        Cow::Borrowed(path)
     };
 
     let mut stream_reader = stream.into_async_read().compat();
     if let Err(err) = archive
-        .append_data(&mut header, path, &mut stream_reader)
+        .append_data(&mut header, &*path, &mut stream_reader)
         .await
     {
         abort_with_error(

--- a/src/esthri/src/http_server.rs
+++ b/src/esthri/src/http_server.rs
@@ -344,6 +344,16 @@ async fn stream_object_to_archive<T: S3 + Send + Clone>(
     header.set_mode(ARCHIVE_ENTRY_MODE);
     header.set_mtime(obj_info.last_modified.timestamp() as u64);
     header.set_size(obj_info.size as u64);
+
+    // Appending the suffix to the path within the archive should
+    // hopefully make dealing with (transparently) compressed files less
+    // confusing
+    let path = if obj_info.is_esthri_compressed() {
+        format!("{}.gz", path)
+    } else {
+        path.to_string()
+    };
+
     let mut stream_reader = stream.into_async_read().compat();
     if let Err(err) = archive
         .append_data(&mut header, path, &mut stream_reader)

--- a/src/esthri/src/http_server.rs
+++ b/src/esthri/src/http_server.rs
@@ -75,14 +75,12 @@ use serde_derive::{Deserialize, Serialize};
 
 const ARCHIVE_ENTRY_MODE: u32 = 0o0644;
 const LAST_MODIFIED_TIME_FMT: &str = "%a, %d %b %Y %H:%M:%S GMT";
-const COMPRESSION_SUFFIX: &str = ".gz";
 
 #[derive(Deserialize)]
 struct DownloadParams {
     archive: Option<bool>,
     archive_name: Option<String>,
     prefixes: Option<S3PrefixList>,
-    from_gz_compressed: Option<bool>,
 }
 
 #[derive(Debug)]
@@ -469,30 +467,12 @@ fn format_prefix_link(prefix: &str) -> Markup {
 
 #[allow(clippy::branches_sharing_code)]
 fn format_object_link(path: &str) -> Markup {
-    let is_gzip_compressed = path.ends_with(COMPRESSION_SUFFIX);
-    let uncompressed_path = match is_gzip_compressed {
-        true => path.strip_suffix(COMPRESSION_SUFFIX).unwrap(),
-        false => path,
-    };
-
     html! {
         div {
             i class="far fa-file fa-fw pe-4" { }
-            @if is_gzip_compressed {
-                a href=(format!("{}?from_gz_compressed=true", uncompressed_path)) {
-                    (uncompressed_path)
-                }
-                span style="color: lightgrey" {
-                    ".gz"
-                }
-            } @else {
                 a href=(path) {
                     (path)
                 }
-            }
-        }
-        @if is_gzip_compressed {
-            (format_archive_download_button(path, &format!("Download {}" ,path)))
         }
     }
 }
@@ -636,26 +616,10 @@ async fn item_pre_response<'a, T: S3 + Send>(
     s3: &T,
     bucket: String,
     path: String,
-    serve_compressed: bool,
     if_none_match: Option<String>,
     mut resp_builder: response::Builder,
 ) -> Result<(response::Builder, Option<(String, String)>), warp::Rejection> {
-    let (obj_info, path, serve_compressed) = match get_obj_info(s3, &bucket, &path).await {
-        Ok(info) => Ok((info, path, serve_compressed)),
-        Err(error) => {
-            if error.is_not_found() && !path.ends_with(COMPRESSION_SUFFIX) {
-                // Allows automatic fallback to the compressed version, if the
-                // non compressed version is requested. This is useful for users
-                // who might be using esthri in 'transparent compression mode',
-                // where they want to embed links between files and are unaware
-                // the files they have uploaded have been compressed.
-                let gz_path = format!("{}{}", &path, COMPRESSION_SUFFIX);
-                Ok((get_obj_info(s3, &bucket, &gz_path).await?, gz_path, true))
-            } else {
-                Err(error)
-            }
-        }
-    }?;
+    let obj_info = get_obj_info(s3, &bucket, &path).await?;
 
     let not_modified = if_none_match
         .map(|etag| etag.strip_prefix("W/").map(String::from).unwrap_or(etag))
@@ -667,7 +631,7 @@ async fn item_pre_response<'a, T: S3 + Send>(
         Ok((resp_builder, None))
     } else {
         resp_builder = resp_builder.header(CONTENT_LENGTH, obj_info.size);
-        resp_builder = resp_builder.header(ETAG, obj_info.e_tag);
+        resp_builder = resp_builder.header(ETAG, &obj_info.e_tag);
         resp_builder = resp_builder.header(CACHE_CONTROL, "private,max-age=0");
         resp_builder = resp_builder.header(
             LAST_MODIFIED,
@@ -677,17 +641,11 @@ async fn item_pre_response<'a, T: S3 + Send>(
                 .to_string(),
         );
 
-        if serve_compressed {
+        if obj_info.is_esthri_compressed() {
             resp_builder = resp_builder.header(CONTENT_ENCODING, "gzip");
         }
 
-        let content_path = if serve_compressed {
-            path.strip_suffix(COMPRESSION_SUFFIX).unwrap_or(&path)
-        } else {
-            &path
-        };
-
-        let mime = mime_guess::from_path(content_path);
+        let mime = mime_guess::from_path(&path);
         let mime = mime.first();
         if let Some(mime) = mime {
             resp_builder = resp_builder.header(CONTENT_TYPE, mime.essence_str());
@@ -808,23 +766,8 @@ async fn download(
             Err(e) => (Some(Body::from(e.to_string())), header),
         }
     } else {
-        let serve_compressed = params.from_gz_compressed.unwrap_or(false);
-
-        let path = if serve_compressed {
-            format!("{}{}", path, COMPRESSION_SUFFIX)
-        } else {
-            path
-        };
-
-        let (resp_builder, create_stream) = item_pre_response(
-            &s3,
-            bucket,
-            path,
-            serve_compressed,
-            if_none_match,
-            resp_builder,
-        )
-        .await?;
+        let (resp_builder, create_stream) =
+            item_pre_response(&s3, bucket, path, if_none_match, resp_builder).await?;
         if let Some((bucket, path)) = create_stream {
             let stream = create_item_stream(s3.clone(), bucket, path).await;
             (Some(Body::wrap_stream(stream)), resp_builder)

--- a/src/esthri/src/lib.rs
+++ b/src/esthri/src/lib.rs
@@ -34,7 +34,6 @@ pub mod errors;
 pub mod http_server;
 pub mod rusoto;
 
-#[cfg(feature = "compression")]
 pub(crate) mod compression;
 pub(crate) mod types;
 
@@ -62,9 +61,8 @@ pub use crate::types::{ObjectInfo, S3ListingItem, S3Object, S3PathParam};
 
 pub use ops::download::download;
 
-#[cfg(feature = "compression")]
 pub use ops::download::download_decompressed;
-#[cfg(feature = "compression")]
+
 pub use ops::upload::upload_compressed;
 
 #[cfg(feature = "http_server")]

--- a/src/esthri/src/lib.rs
+++ b/src/esthri/src/lib.rs
@@ -62,7 +62,6 @@ pub use crate::types::{ObjectInfo, S3ListingItem, S3Object, S3PathParam};
 pub use ops::download::download;
 
 pub use ops::download::download_with_transparent_decompression;
-
 pub use ops::upload::upload_compressed;
 
 #[cfg(feature = "http_server")]

--- a/src/esthri/src/lib.rs
+++ b/src/esthri/src/lib.rs
@@ -61,7 +61,7 @@ pub use crate::types::{ObjectInfo, S3ListingItem, S3Object, S3PathParam};
 
 pub use ops::download::download;
 
-pub use ops::download::download_decompressed;
+pub use ops::download::download_with_transparent_decompression;
 
 pub use ops::upload::upload_compressed;
 

--- a/src/esthri/src/main.rs
+++ b/src/esthri/src/main.rs
@@ -119,7 +119,6 @@ enum EsthriCommand {
     /// Upload an object to S3
     Put {
         /// Should the file be compressed during upload
-
         #[structopt(long)]
         compress: bool,
         /// The target bucket (example: my-bucket)
@@ -134,7 +133,6 @@ enum EsthriCommand {
     /// Download an object from S3
     Get {
         /// Should the file be decompressed during download
-
         #[structopt(long)]
         transparent_compression: bool,
         /// The target bucket (example: my-bucket)
@@ -173,9 +171,8 @@ enum EsthriCommand {
         /// Optional exclude glob pattern (see `man 3 glob`)
         #[structopt(long)]
         exclude: Option<Vec<Pattern>>,
-
-        #[structopt(long)]
         /// Enable compression, only valid on upload
+        #[structopt(long)]
         transparent_compression: bool,
     },
     /// Retreive the ETag for a remote object
@@ -281,7 +278,6 @@ async fn dispatch_aws_cli(cmd: AwsCommand, s3: &S3Client) -> Result<()> {
                     ref destination,
                     ref include,
                     ref exclude,
-
                     transparent_compression: compress,
                     ..
                 } => {

--- a/src/esthri/src/main.rs
+++ b/src/esthri/src/main.rs
@@ -403,7 +403,7 @@ async fn dispatch_esthri_cli(cmd: EsthriCommand, s3: &S3Client) -> Result<()> {
                     ..
                 }
             ) {
-                download_decompressed(s3, bucket, key, file).await?;
+                download_with_transparent_decompression(s3, bucket, key, file).await?;
             } else {
                 download(s3, bucket, key, file).await?;
             }

--- a/src/esthri/src/ops/copy.rs
+++ b/src/esthri/src/ops/copy.rs
@@ -15,7 +15,7 @@
 use crate::errors::{Error, Result};
 use crate::{download, upload, S3PathParam};
 
-use crate::{download_decompressed, upload_compressed};
+use crate::{download_with_transparent_decompression, upload_compressed};
 use log_derive::logfn;
 use rusoto_s3::S3;
 
@@ -24,7 +24,7 @@ pub async fn copy<T>(
     s3: &T,
     source: S3PathParam,
     destination: S3PathParam,
-    compress: bool,
+    transparent_compression: bool,
 ) -> Result<()>
 where
     T: S3 + Sync + Send + Clone,
@@ -32,17 +32,8 @@ where
     match source {
         S3PathParam::Bucket { bucket, key } => match destination {
             S3PathParam::Local { path } => {
-                if compress {
-                    match download_decompressed(s3, &bucket, &key, &path).await {
-                        Ok(_) => Ok(()),
-                        Err(error) => match error {
-                            Error::GetObjectInvalidKey(_) => {
-                                let compressed_key = key + ".gz";
-                                download_decompressed(s3, bucket, compressed_key, path).await
-                            }
-                            _ => Err(error),
-                        },
-                    }
+                if transparent_compression {
+                    download_with_transparent_decompression(s3, bucket, key, path).await
                 } else {
                     download(s3, bucket, key, path).await
                 }
@@ -53,7 +44,7 @@ where
         },
         S3PathParam::Local { path } => match destination {
             S3PathParam::Bucket { bucket, key } => {
-                if compress {
+                if transparent_compression {
                     upload_compressed(s3, bucket, key, path).await
                 } else {
                     upload(s3, bucket, key, path).await

--- a/src/esthri/src/ops/copy.rs
+++ b/src/esthri/src/ops/copy.rs
@@ -14,7 +14,7 @@
 
 use crate::errors::{Error, Result};
 use crate::{download, upload, S3PathParam};
-#[cfg(feature = "compression")]
+
 use crate::{download_decompressed, upload_compressed};
 use log_derive::logfn;
 use rusoto_s3::S3;
@@ -33,22 +33,15 @@ where
         S3PathParam::Bucket { bucket, key } => match destination {
             S3PathParam::Local { path } => {
                 if compress {
-                    #[cfg(feature = "compression")]
-                    {
-                        match download_decompressed(s3, &bucket, &key, &path).await {
-                            Ok(_) => Ok(()),
-                            Err(error) => match error {
-                                Error::GetObjectInvalidKey(_) => {
-                                    let compressed_key = key + ".gz";
-                                    download_decompressed(s3, bucket, compressed_key, path).await
-                                }
-                                _ => Err(error),
-                            },
-                        }
-                    }
-                    #[cfg(not(feature = "compression"))]
-                    {
-                        panic!("compression feature not enabled");
+                    match download_decompressed(s3, &bucket, &key, &path).await {
+                        Ok(_) => Ok(()),
+                        Err(error) => match error {
+                            Error::GetObjectInvalidKey(_) => {
+                                let compressed_key = key + ".gz";
+                                download_decompressed(s3, bucket, compressed_key, path).await
+                            }
+                            _ => Err(error),
+                        },
                     }
                 } else {
                     download(s3, bucket, key, path).await
@@ -61,14 +54,7 @@ where
         S3PathParam::Local { path } => match destination {
             S3PathParam::Bucket { bucket, key } => {
                 if compress {
-                    #[cfg(feature = "compression")]
-                    {
-                        upload_compressed(s3, bucket, key, path).await
-                    }
-                    #[cfg(not(feature = "compression"))]
-                    {
-                        panic!("compression feature not enabled");
-                    }
+                    upload_compressed(s3, bucket, key, path).await
                 } else {
                     upload(s3, bucket, key, path).await
                 }

--- a/src/esthri/src/ops/download.rs
+++ b/src/esthri/src/ops/download.rs
@@ -91,11 +91,12 @@ where
 {
     let read_expected = range.read_size();
     let mut blob = vec![0u8; read_expected as usize];
+    let stat = head_object_request(s3, bucket.clone(), key.clone())
+        .await?
+        .ok_or_else(|| Error::GetObjectInvalidKey(key.clone()))?;
     loop {
         let result = reader.read_exact(&mut blob).await;
-        let stat = head_object_request(s3, bucket.clone(), key.clone())
-            .await?
-            .ok_or_else(|| Error::GetObjectInvalidKey(key.clone()))?;
+
         if stat.size as u64 != range.total() {
             break Err(Error::GetObjectSizeChanged);
         }

--- a/src/esthri/src/ops/download.rs
+++ b/src/esthri/src/ops/download.rs
@@ -16,7 +16,6 @@ use std::fs::create_dir_all;
 use std::marker::Unpin;
 use std::path::Path;
 use std::pin::Pin;
-
 use std::sync::{Arc, Mutex};
 
 use futures::future::BoxFuture;
@@ -30,7 +29,6 @@ use flate2::write::GzDecoder;
 /// Internal module used to call out operations that may block.
 mod bio {
     pub(super) use std::fs::File;
-
     pub(super) use std::io::prelude::*;
     pub(super) use std::io::ErrorKind;
     pub(super) use tempfile::NamedTempFile;
@@ -44,7 +42,6 @@ use crate::{handle_dispatch_error, head_object_request};
 
 /// Unique (locked) pointer to a type that implements the [std::io::Write] trait used here to hold a
 /// pointer to an object that implements gzip decompression transparently.
-
 type LockedBoxedWrite = Arc<Mutex<Box<dyn bio::Write + Unpin + Send + Sync>>>;
 
 async fn get_object_request<T>(
@@ -248,7 +245,6 @@ impl Downloader for DownloadMultiple {
 
 /// `DownloadCompressedChunk` uses multiple readers and 1 writer concurrently to download compressed
 /// files and uncompress them transparently.
-
 struct DownloadCompressedChunk {
     writer: LockedBoxedWrite,
     buffer: Vec<u8>,

--- a/src/esthri/src/ops/sync.rs
+++ b/src/esthri/src/ops/sync.rs
@@ -12,7 +12,11 @@
 
 #![cfg_attr(feature = "aggressive_lint", deny(warnings))]
 
-use std::path::{Path, PathBuf};
+use std::{
+    fs::{self, File},
+    io::BufReader,
+    path::{Path, PathBuf},
+};
 
 use futures::{Future, Stream, StreamExt, TryStreamExt};
 use glob::Pattern;
@@ -21,6 +25,7 @@ use log_derive::logfn;
 use walkdir::WalkDir;
 
 use crate::{
+    compression::compress_to_tempfile,
     compute_etag,
     config::Config,
     errors::{Error, Result},
@@ -30,7 +35,14 @@ use crate::{
     types::{S3ListingItem, S3PathParam},
 };
 
-type MapEtagResult = Result<(PathBuf, Result<String>, Option<ListingMetadata>)>;
+struct MappedPathResult {
+    file_path: Box<dyn AsRef<Path>>,
+    source_path: PathBuf,
+    local_etag: Result<String>,
+    metadata: Option<ListingMetadata>,
+}
+
+type MapPathResult = Result<MappedPathResult>;
 
 #[derive(Debug, Clone)]
 pub enum GlobFilter {
@@ -197,62 +209,68 @@ enum SyncCompressionDirection {
     Down,
 }
 
-fn map_paths_to_etags<StreamT>(
+fn translate_paths<StreamT>(
     input_stream: StreamT,
     compressed: SyncCompressionDirection,
-) -> impl Stream<Item = impl Future<Output = MapEtagResult>>
+) -> impl Stream<Item = impl Future<Output = MapPathResult>>
 where
     StreamT: Stream<Item = Result<(String, Option<ListingMetadata>)>>,
 {
     use std::str::FromStr;
     input_stream.map(move |params| async move {
         let (path, metadata) = params?;
-        let path = PathBuf::from_str(&path)?;
+        let source_path = PathBuf::from_str(&path)?;
+        let file_path: Box<dyn AsRef<Path>> = Box::new(path);
 
-        use crate::compression::{
-            compress_and_replace, compress_to_tempfile, compressed_path_to_path,
-        };
-
-        let (path, local_etag) = match compressed {
+        let (file_path, source_path, local_etag) = match compressed {
             SyncCompressionDirection::None => {
-                let local_etag = compute_etag(&path).await;
-                (path, local_etag)
+                let local_etag = compute_etag(&source_path).await;
+                (file_path, source_path, local_etag)
             }
             SyncCompressionDirection::Up => {
-                if path.extension().map(|e| e == "gz").unwrap_or(false) {
-                    let local_etag = compute_etag(&path).await;
-                    (path, local_etag)
-                } else {
-                    info!("compressing and replacing: {}", path.display());
-                    let path = compress_and_replace(path).await?;
-                    let local_etag = compute_etag(&path).await;
-                    (path, local_etag)
-                }
+                // If we're syncing up with compression, then everything
+                // should be compressed
+                let (temp_compressed, _) = compress_to_tempfile(&source_path).await?;
+                let local_etag = compute_etag(&temp_compressed).await;
+
+                let temp_path = temp_compressed.into_temp_path();
+                let path: Box<dyn AsRef<Path>> = Box::new(temp_path);
+                (path, source_path, local_etag)
             }
             SyncCompressionDirection::Down => {
-                if path.extension().map(|e| e == "gz").unwrap_or(false) {
-                    let uncompressed_path =
-                        compressed_path_to_path(&path).expect("Path should be compressed");
-
-                    if !uncompressed_path.exists() {
-                        (path, Err(Error::ETagNotPresent))
+                // if we're syncing down with compression, then there
+                // could be both esthri compressed files and non
+                // compressed files within the prefix. We should only
+                // try to decompress the esthri compressed files
+                if metadata
+                    .as_ref()
+                    .expect("Should have metadata")
+                    .esthri_compressed
+                {
+                    if !source_path.exists() {
+                        (file_path, source_path, Err(Error::ETagNotPresent))
                     } else {
                         // Check if we already have a copy locally
                         // of the uncompressed file by recompressing
                         // the local file to see if it matches with
                         // the compressed version
-                        let (temp_compressed, _) = compress_to_tempfile(&uncompressed_path).await?;
+                        let (temp_compressed, _) = compress_to_tempfile(&source_path).await?;
                         let local_etag = compute_etag(&temp_compressed).await;
-                        (path, local_etag)
+                        (file_path, source_path, local_etag)
                     }
                 } else {
-                    let local_etag = compute_etag(&path).await;
-                    (path, local_etag)
+                    let local_etag = compute_etag(&source_path).await;
+                    (file_path, source_path, local_etag)
                 }
             }
         };
 
-        Ok((path, local_etag, metadata))
+        Ok(MappedPathResult {
+            file_path,
+            source_path,
+            local_etag,
+            metadata,
+        })
     })
 }
 
@@ -262,12 +280,13 @@ fn local_to_remote_sync_tasks<ClientT, StreamT>(
     key: String,
     directory: PathBuf,
     dirent_stream: StreamT,
+    transparent_compression: bool,
 ) -> impl Stream<Item = impl Future<Output = Result<()>>>
 where
     ClientT: S3 + Send + Clone,
-    StreamT: Stream<Item = MapEtagResult>,
+    StreamT: Stream<Item = MapPathResult>,
 {
-    use super::upload::upload;
+    use super::upload::upload_from_reader;
     dirent_stream
         .map(move |entry| {
             (
@@ -280,13 +299,21 @@ where
         })
         .map(move |clones| async move {
             let (s3, bucket, key, directory, entry) = clones;
-            let (path, local_etag, _metadata) = entry;
-            let path = Path::new(&path);
+            let MappedPathResult {
+                file_path: filepath,
+                source_path,
+                local_etag,
+                ..
+            } = entry;
+            let path = Path::new(&source_path);
             let remote_path = Path::new(&key);
             let stripped_path = path.strip_prefix(&directory);
             let stripped_path = match stripped_path {
                 Err(e) => {
-                    warn!("unexpected: failed to strip prefix: {}", e);
+                    warn!(
+                        "unexpected: failed to strip prefix: {}, {:?}, {:?}",
+                        e, &path, &directory
+                    );
                     return Ok(());
                 }
                 Ok(result) => result,
@@ -296,6 +323,12 @@ where
             debug!("checking remote: {}", remote_path);
             let local_etag = local_etag?;
             let object_info = head_object_request(&s3, &bucket, &remote_path).await?;
+            let metadata = if transparent_compression {
+                Some(crate::compression::compressed_file_metadata())
+            } else {
+                None
+            };
+
             if let Some(object_info) = object_info {
                 let remote_etag = object_info.e_tag;
                 if remote_etag != local_etag {
@@ -303,7 +336,9 @@ where
                         "etag mis-match: {}, remote_etag={}, local_etag={}",
                         remote_path, remote_etag, local_etag
                     );
-                    upload(&s3, bucket, &remote_path, &path).await?;
+                    let reader = BufReader::new(File::open(&*filepath)?);
+                    let size = fs::metadata(&*filepath)?.len();
+                    upload_from_reader(&s3, bucket, remote_path, reader, size, metadata).await?;
                 } else {
                     debug!(
                         "etags matched: {}, remote_etag={}, local_etag={}",
@@ -312,7 +347,9 @@ where
                 }
             } else {
                 info!("file did not exist remotely: {}", remote_path);
-                upload(&s3, bucket, &remote_path, &path).await?;
+                let reader = BufReader::new(File::open(&*filepath)?);
+                let size = fs::metadata(&*filepath)?.len();
+                upload_from_reader(&s3, bucket, remote_path, reader, size, metadata).await?;
             }
             Ok(())
         })
@@ -338,13 +375,14 @@ where
         SyncCompressionDirection::None
     };
 
-    let etag_stream = map_paths_to_etags(dirent_stream, compression).buffer_unordered(task_count);
+    let etag_stream = translate_paths(dirent_stream, compression).buffer_unordered(task_count);
     let sync_tasks = local_to_remote_sync_tasks(
         s3.clone(),
         bucket.into(),
         key.into(),
         directory.into(),
         etag_stream,
+        compressed,
     );
 
     sync_tasks
@@ -436,6 +474,7 @@ fn flattened_object_listing<'a, ClientT>(
     key: &'a str,
     directory: &'a Path,
     filters: &'a [GlobFilter],
+    transparent_decompress: bool,
 ) -> impl Stream<Item = Result<(String, Option<ListingMetadata>)>> + 'a
 where
     ClientT: S3 + Send + Clone,
@@ -449,12 +488,19 @@ where
                     for entry in entries {
                         let entry = entry.unwrap_object();
                         debug!("key={}", entry.key);
+
+                        let compressed = if transparent_decompress {
+                            head_object_request(s3, bucket, &entry.key).await?.expect("No head info?").is_esthri_compressed()
+                        } else {
+                            false
+                        };
+
                         let path_result = Path::new(&entry.key).strip_prefix(key);
                         if let Ok(s3_suffix) = path_result {
                             if process_globs(&s3_suffix, filters).is_some() {
                                 let local_path: String = directory.join(&s3_suffix).to_string_lossy().into();
                                 let s3_suffix = s3_suffix.to_string_lossy().into();
-                                yield Ok((local_path, ListingMetadata::some(s3_suffix, entry.e_tag)));
+                                yield Ok((local_path, ListingMetadata::some(s3_suffix, entry.e_tag, compressed)));
                             }
                         } else {
                             yield Err(path_result.err().unwrap().into());
@@ -478,11 +524,11 @@ fn remote_to_local_sync_tasks<ClientT, StreamT>(
     key: String,
     directory: PathBuf,
     input_stream: StreamT,
-    decompress: bool,
+    transparent_decompress: bool,
 ) -> impl Stream<Item = impl Future<Output = Result<()>>>
 where
     ClientT: S3 + Sync + Send + Clone,
-    StreamT: Stream<Item = MapEtagResult>,
+    StreamT: Stream<Item = MapPathResult>,
 {
     use super::download::download_with_dir;
     input_stream
@@ -492,20 +538,25 @@ where
                 bucket.clone(),
                 key.clone(),
                 directory.clone(),
-                decompress,
+                transparent_decompress,
                 entry.unwrap(),
             )
         })
         .map(
             |(s3, bucket, key, directory, decompress, entry)| async move {
-                let (path, local_etag, metadata) = entry;
+                let MappedPathResult {
+                    source_path,
+                    local_etag,
+                    metadata,
+                    ..
+                } = entry;
                 let metadata = metadata.unwrap();
                 match local_etag {
                     Ok(local_etag) => {
                         if local_etag != metadata.e_tag {
                             debug!(
                                 "etag mismatch: {}, local etag={}, remote etag={}",
-                                path.display(),
+                                source_path.display(),
                                 local_etag,
                                 metadata.e_tag
                             );
@@ -519,12 +570,12 @@ where
                             )
                             .await?;
                         } else {
-                            debug!("etag match: {}", path.display());
+                            debug!("etag match: {}", source_path.display());
                         }
                     }
                     Err(err) => match err {
                         Error::ETagNotPresent => {
-                            debug!("file did not exist locally: {}", path.display());
+                            debug!("file did not exist locally: {}", source_path.display());
                             download_with_dir(
                                 &s3,
                                 &bucket,
@@ -551,29 +602,30 @@ async fn sync_remote_to_local<T>(
     key: &str,
     directory: impl AsRef<Path>,
     filters: &[GlobFilter],
-    decompress: bool,
+    transparent_decompress: bool,
 ) -> Result<()>
 where
     T: S3 + Sync + Send + Clone,
 {
     let directory = directory.as_ref();
     let task_count = Config::global().concurrent_sync_tasks();
-    let object_listing = flattened_object_listing(s3, bucket, key, directory, filters);
+    let object_listing =
+        flattened_object_listing(s3, bucket, key, directory, filters, transparent_decompress);
 
-    let compression = if decompress {
+    let compression = if transparent_decompress {
         SyncCompressionDirection::Down
     } else {
         SyncCompressionDirection::None
     };
 
-    let etag_stream = map_paths_to_etags(object_listing, compression).buffer_unordered(task_count);
+    let etag_stream = translate_paths(object_listing, compression).buffer_unordered(task_count);
     let sync_tasks = remote_to_local_sync_tasks(
         s3.clone(),
         bucket.into(),
         key.into(),
         directory.into(),
         etag_stream,
-        decompress,
+        transparent_decompress,
     );
 
     sync_tasks

--- a/src/esthri/src/ops/upload.rs
+++ b/src/esthri/src/ops/upload.rs
@@ -12,6 +12,7 @@
 
 #![cfg_attr(feature = "aggressive_lint", deny(warnings))]
 
+use std::borrow::Cow;
 use std::sync::Mutex;
 use std::{collections::HashMap, path::Path};
 
@@ -107,7 +108,7 @@ where
     // key="s3://mybucket/myprefix1/myprefix/" then the file will be uploaded as
     // s3://mybucket/myprefix1/myprefix/{filename from path}.
     let key = if !key.ends_with('/') {
-        key.to_string()
+        Cow::Borrowed(key)
     } else {
         let filename = path
             .file_name()
@@ -115,7 +116,7 @@ where
             .to_str()
             .ok_or(Error::CouldNotParseS3Filename)?;
 
-        format!("{}{}", key, filename)
+        Cow::Owned(format!("{}{}", key, filename))
     };
 
     if path.exists() {

--- a/src/esthri/src/ops/upload.rs
+++ b/src/esthri/src/ops/upload.rs
@@ -125,24 +125,17 @@ where
     if path.exists() {
         let stat = fs::metadata(&path)?;
         if compressed {
-            #[cfg(feature = "compression")]
-            {
-                use crate::compression::compress_to_tempfile;
-                let (compressed, size) = compress_to_tempfile(path.clone()).await?;
-                upload_from_reader(
-                    s3,
-                    bucket,
-                    key,
-                    compressed,
-                    size,
-                    Some(crate::compression::compressed_file_metadata()),
-                )
-                .await
-            }
-            #[cfg(not(feature = "compression"))]
-            {
-                panic!("compression feature not enabled");
-            }
+            use crate::compression::compress_to_tempfile;
+            let (compressed, size) = compress_to_tempfile(path.clone()).await?;
+            upload_from_reader(
+                s3,
+                bucket,
+                key,
+                compressed,
+                size,
+                Some(crate::compression::compressed_file_metadata()),
+            )
+            .await
         } else {
             let size = stat.len();
             debug!("upload: file size: {}", size);
@@ -175,7 +168,6 @@ where
     upload_helper(s3, bucket, key, file, compressed).await
 }
 
-#[cfg(feature = "compression")]
 #[logfn(err = "ERROR")]
 pub async fn upload_compressed<T>(
     s3: &T,

--- a/src/esthri/src/ops/upload.rs
+++ b/src/esthri/src/ops/upload.rs
@@ -115,11 +115,7 @@ where
             .to_str()
             .ok_or(Error::CouldNotParseS3Filename)?;
 
-        if compressed {
-            format!("{}{}.gz", key, filename)
-        } else {
-            format!("{}{}", key, filename)
-        }
+        format!("{}{}", key, filename)
     };
 
     if path.exists() {

--- a/src/esthri/src/types.rs
+++ b/src/esthri/src/types.rs
@@ -31,6 +31,13 @@ pub struct ObjectInfo {
     pub metadata: HashMap<String, String>,
 }
 
+impl ObjectInfo {
+    pub fn is_esthri_compressed(&self) -> bool {
+        self.metadata
+            .contains_key(crate::compression::ESTHRI_METADATA_COMPRESS_KEY)
+    }
+}
+
 #[derive(Debug, Clone)]
 pub enum S3PathParam {
     Local { path: PathBuf },
@@ -197,11 +204,16 @@ impl ReadState {
 pub(super) struct ListingMetadata {
     pub(super) s3_suffix: String,
     pub(super) e_tag: String,
+    pub(super) esthri_compressed: bool,
 }
 
 impl ListingMetadata {
-    pub(super) fn some(s3_suffix: String, e_tag: String) -> Option<Self> {
-        Some(Self { s3_suffix, e_tag })
+    pub(super) fn some(s3_suffix: String, e_tag: String, esthri_compressed: bool) -> Option<Self> {
+        Some(Self {
+            s3_suffix,
+            e_tag,
+            esthri_compressed,
+        })
     }
     pub(super) fn none() -> Option<Self> {
         None

--- a/src/esthri/tests/data/compressed.html.gz
+++ b/src/esthri/tests/data/compressed.html.gz
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:646f000bf889e17840462369c1ff94fe1fff4ee6d39b6198dbbc9028dc046b84
-size 71

--- a/src/esthri/tests/data/index.html
+++ b/src/esthri/tests/data/index.html
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:c82a1278b782fa8b6fed87b097d5107b2c0732da5f0a656d93d8db32b9cb1b67
+size 39

--- a/src/esthri/tests/integration/cli_test.rs
+++ b/src/esthri/tests/integration/cli_test.rs
@@ -123,36 +123,6 @@ fn test_aws_fallthrough_cp_option() {
 }
 
 #[test]
-fn test_cp_falls_back_with_compression() {
-    let mut cmd = Command::cargo_bin("esthri").unwrap();
-    let local_dir = TempDir::new("esthri_cli").unwrap();
-    let local_dir_path = local_dir.path().to_str().unwrap();
-    // this file doesn't exist on S3, but
-    // s3://esthri-test/test_download/27-185232-msg.csv.gz does. In
-    // compression mode, esthri should fall back to downloading (and
-    // decompressing) the compressed version transparently.
-    let key = "s3://esthri-test/test_download/27-185232-msg.csv";
-    let assert = cmd
-        .env("ESTHRI_AWS_COMPAT_MODE", "1")
-        .env("ESTHRI_AWS_COMPAT_MODE_COMPRESSION", "1")
-        .arg("s3")
-        .arg("cp")
-        .arg(key)
-        .arg(local_dir_path)
-        .assert();
-
-    assert.success();
-
-    validate_key_hash_pairs(
-        local_dir_path,
-        &[KeyHashPair(
-            "27-185232-msg.csv",
-            "e8b32017e42f2e727316d68ea72c2832",
-        )],
-    );
-}
-
-#[test]
 fn test_aws_sync_down_filter() {
     let sync_from = "s3://esthri-test/test_sync_down_default";
     let local_dir = TempDir::new("esthri_cli").unwrap();

--- a/src/esthri/tests/integration/cli_test.rs
+++ b/src/esthri/tests/integration/cli_test.rs
@@ -122,7 +122,6 @@ fn test_aws_fallthrough_cp_option() {
     assert.success().stdout("s3 ls\n");
 }
 
-#[cfg(feature = "compression")]
 #[test]
 fn test_cp_falls_back_with_compression() {
     let mut cmd = Command::cargo_bin("esthri").unwrap();

--- a/src/esthri/tests/integration/cli_test.rs
+++ b/src/esthri/tests/integration/cli_test.rs
@@ -216,3 +216,64 @@ fn test_aws_sync_down_filter_include_only() {
     validate_key_hash_pairs(sync_to, &key_hash_pairs);
     assert!(fs::remove_dir_all(sync_to).is_ok());
 }
+
+#[test]
+fn test_sync_transparent_compression() {
+    let local_dir = TempDir::new("esthri_cli").unwrap();
+    let local_path = local_dir.path().to_str().unwrap();
+    let s3_path = "s3://esthri-test/test-syncup-compress/";
+
+    let mut cmd = Command::cargo_bin("esthri").unwrap();
+    let assert = cmd
+        .env("ESTHRI_AWS_COMPAT_MODE", "1")
+        .arg("s3")
+        .arg("sync")
+        .arg("--transparent-compression")
+        .arg("tests/data/sync_up/")
+        .arg(s3_path)
+        .assert();
+    assert.success();
+
+    // Downloading with transparent compression should get the uncompressed files
+    let mut cmd = Command::cargo_bin("esthri").unwrap();
+    let assert = cmd
+        .env("ESTHRI_AWS_COMPAT_MODE", "1")
+        .arg("s3")
+        .arg("sync")
+        .arg("--transparent-compression")
+        .arg(s3_path)
+        .arg(local_path)
+        .assert();
+    assert.success();
+
+    let key_hash_pairs = [
+        KeyHashPair("1-one.data", "827aa1b392c93cb25d2348bdc9b907b0"),
+        KeyHashPair("2-two.bin", "35500e07a35b413fc5f434397a4c6bfa"),
+        KeyHashPair("3-three.junk", "388f9763d78cecece332459baecb4b85"),
+        KeyHashPair("nested/2MiB.bin", "64a2635e42ef61c69d62feebdbf118d4"),
+    ];
+
+    validate_key_hash_pairs(local_path, &key_hash_pairs);
+
+    // But downloading without transparent compression should get the compressed files
+    let local_dir = TempDir::new("esthri_cli").unwrap();
+    let local_path = local_dir.path().to_str().unwrap();
+    let mut cmd = Command::cargo_bin("esthri").unwrap();
+    let assert = cmd
+        .env("ESTHRI_AWS_COMPAT_MODE", "1")
+        .arg("s3")
+        .arg("sync")
+        .arg(s3_path)
+        .arg(local_path)
+        .assert();
+    assert.success();
+
+    let key_hash_pairs = [
+        KeyHashPair("1-one.data", "276ebe187bb53cb68e484e8c0c0fef68"),
+        KeyHashPair("2-two.bin", "2b08f95817755fc00c1cc1e528dc7db8"),
+        KeyHashPair("3-three.junk", "12bc292b0d53b61203b839588213a9a1"),
+        KeyHashPair("nested/2MiB.bin", "da4b426cae11741846271040d9b4dc71"),
+    ];
+
+    validate_key_hash_pairs(local_path, &key_hash_pairs);
+}

--- a/src/esthri/tests/integration/download_test.rs
+++ b/src/esthri/tests/integration/download_test.rs
@@ -75,7 +75,6 @@ async fn test_download_zero_size() {
     assert_eq!(stat.len(), 0);
 }
 
-#[cfg(feature = "compression")]
 #[test]
 fn test_download_decompressed() {
     let s3client = crate::get_s3client();
@@ -93,7 +92,6 @@ fn test_download_decompressed() {
     assert_eq!(etag, "\"6dbb4258fa16030c2daf6f1eac93dddd-8\"");
 }
 
-#[cfg(feature = "compression")]
 #[test]
 fn test_download_decompressed_to_directory() {
     let s3client = crate::get_s3client();

--- a/src/esthri/tests/integration/download_test.rs
+++ b/src/esthri/tests/integration/download_test.rs
@@ -84,8 +84,12 @@ fn test_download_decompressed() {
     let filename = "27-185232-msg.csv";
     let s3_key = format!("test_download/{}.gz", filename);
 
-    let res =
-        blocking::download_decompressed(s3client.as_ref(), crate::TEST_BUCKET, &s3_key, &filename);
+    let res = blocking::download_with_transparent_decompression(
+        s3client.as_ref(),
+        crate::TEST_BUCKET,
+        &s3_key,
+        &filename,
+    );
     assert!(res.is_ok());
 
     let etag = blocking::compute_etag(filename).unwrap();
@@ -98,10 +102,15 @@ fn test_download_decompressed_to_directory() {
     let _tmp_dir = crate::EphemeralTempDir::pushd();
 
     // Test object `test_download/27-185232-msg.csv.gz` must be prepopulated in the S3 bucket
-    let filename = "27-185232-msg.csv";
-    let s3_key = format!("test_download/{}.gz", filename);
+    let filename = "27-185232-msg.csv.gz";
+    let s3_key = format!("test_download/{}", filename);
 
-    let res = blocking::download_decompressed(s3client.as_ref(), crate::TEST_BUCKET, &s3_key, ".");
+    let res = blocking::download_with_transparent_decompression(
+        s3client.as_ref(),
+        crate::TEST_BUCKET,
+        &s3_key,
+        ".",
+    );
     assert!(res.is_ok());
 
     let etag = blocking::compute_etag(filename).unwrap();

--- a/src/esthri/tests/integration/download_test.rs
+++ b/src/esthri/tests/integration/download_test.rs
@@ -3,6 +3,8 @@
 use esthri::{blocking, download};
 use tempdir::TempDir;
 
+use crate::{validate_key_hash_pairs, KeyHashPair};
+
 #[test]
 fn test_download() {
     let s3client = crate::get_s3client();
@@ -115,4 +117,29 @@ fn test_download_decompressed_to_directory() {
 
     let etag = blocking::compute_etag(filename).unwrap();
     assert_eq!(etag, "\"6dbb4258fa16030c2daf6f1eac93dddd-8\"");
+}
+
+#[test]
+fn test_download_transparent_with_non_compressed() {
+    let s3client = crate::get_s3client();
+
+    let local_dir = TempDir::new("esthri_cli").unwrap();
+    let local_dir_path = local_dir.path().as_os_str().to_str().unwrap();
+    let filename = "test_file.txt";
+    let s3_key = format!("test_folder/{}", filename);
+
+    let res = blocking::download_with_transparent_decompression(
+        s3client.as_ref(),
+        crate::TEST_BUCKET,
+        &s3_key,
+        local_dir_path,
+    );
+    assert!(res.is_ok());
+
+    let key_hash_pairs = [KeyHashPair(
+        "test_file.txt",
+        "8fd41740698064016b7daaddddd3531a",
+    )];
+
+    validate_key_hash_pairs(local_dir_path, &key_hash_pairs);
 }

--- a/src/esthri/tests/integration/http_server.rs
+++ b/src/esthri/tests/integration/http_server.rs
@@ -222,3 +222,38 @@ fn test_fetch_archive_prefixes() {
         key_hash_pairs,
     );
 }
+
+#[test]
+fn test_fetch_archive_with_compressed_files() {
+    let prefix = "test_fetch_archive_compressed";
+
+    let filename = "tests/data/index.html".to_owned();
+    let s3client = crate::get_s3client();
+    let s3_key = format!("{}/{}", prefix, "index_compressed.html");
+    let res =
+        blocking::upload_compressed(s3client.as_ref(), crate::TEST_BUCKET, &s3_key, &filename);
+    assert!(res.is_ok());
+
+    let filename = "tests/data/index.html".to_owned();
+    let s3client = crate::get_s3client();
+    let s3_key = format!("{}/{}", prefix, "index_notcompressed.html");
+    let res = blocking::upload(s3client.as_ref(), crate::TEST_BUCKET, &s3_key, &filename);
+    assert!(res.is_ok());
+
+    let key_hash_pairs: Vec<KeyHashPair> = vec![
+        KeyHashPair(
+            "index_compressed.html.gz",
+            "3f945ffd0cf39f07d927d8752526caad",
+        ),
+        KeyHashPair(
+            "index_notcompressed.html",
+            "b4e3f354e8575e2fa5f489ab6078917c",
+        ),
+    ];
+
+    test_fetch_archive_helper(
+        "/test_fetch_archive_compressed/?archive=true",
+        "test_fetch_archive_compressed",
+        key_hash_pairs,
+    );
+}

--- a/src/esthri/tests/integration/http_server.rs
+++ b/src/esthri/tests/integration/http_server.rs
@@ -9,9 +9,9 @@ use tar::Archive;
 
 use tokio::runtime::Runtime;
 
-use esthri::blocking;
 use esthri::http_server::esthri_filter;
 use esthri::upload;
+use esthri::{blocking, upload_compressed};
 
 use crate::{validate_key_hash_pairs, DateTime, KeyHashPair};
 
@@ -40,38 +40,11 @@ async fn test_fetch_object() {
 }
 
 async fn upload_compressed_html_file() {
-    let filename = "tests/data/compressed.html.gz".to_owned();
+    let filename = "tests/data/index.html".to_owned();
     let s3client = crate::get_s3client();
-    let s3_key = "compressed.html.gz".to_owned();
-    let res = upload(s3client.as_ref(), crate::TEST_BUCKET, &s3_key, &filename).await;
+    let s3_key = "index_compressed.html".to_owned();
+    let res = upload_compressed(s3client.as_ref(), crate::TEST_BUCKET, &s3_key, &filename).await;
     assert!(res.is_ok());
-}
-
-/// Ensures that an object path will fallback to the gzipped version, if the
-/// path doesn't exist
-#[tokio::test]
-async fn test_fetch_compressed_object_fallback() {
-    upload_compressed_html_file().await;
-    let s3client = crate::get_s3client();
-    let filter = esthri_filter((*s3client).clone(), crate::TEST_BUCKET);
-
-    let mut result = warp::test::request()
-        .path("/compressed.html")
-        .filter(&filter)
-        .await
-        .unwrap();
-
-    let headers = result.headers();
-    assert_eq!(headers["content-type"], "text/html");
-    assert_eq!(headers["content-encoding"], "gzip");
-
-    let body = hyper::body::to_bytes(result.body_mut()).await.unwrap();
-    let digest = md5::compute(body);
-    assert_eq!(
-        format!("{:x}", digest),
-        "14ca7578687b016e4633be7fc26fa05e",
-        "md5 digest did not match"
-    );
 }
 
 /// Ensures that getting an object with `from_gz_compressed` specified sets the
@@ -84,7 +57,7 @@ async fn test_fetch_compressed_object_encoding() {
     let filter = esthri_filter((*s3client).clone(), crate::TEST_BUCKET);
 
     let mut result = warp::test::request()
-        .path("/compressed.html?from_gz_compressed=true")
+        .path("/index_compressed.html")
         .filter(&filter)
         .await
         .unwrap();
@@ -97,34 +70,7 @@ async fn test_fetch_compressed_object_encoding() {
     let digest = md5::compute(body);
     assert_eq!(
         format!("{:x}", digest),
-        "14ca7578687b016e4633be7fc26fa05e",
-        "md5 digest did not match"
-    );
-}
-
-/// Tests that directly accessing the compressed path will allow downloading the
-/// compressed file
-#[tokio::test]
-async fn test_fetch_compresed_object_as_compressed() {
-    upload_compressed_html_file().await;
-    let s3client = crate::get_s3client();
-
-    let filter = esthri_filter((*s3client).clone(), crate::TEST_BUCKET);
-
-    let mut result = warp::test::request()
-        .path("/compressed.html.gz")
-        .filter(&filter)
-        .await
-        .unwrap();
-
-    let headers = result.headers();
-    assert_eq!(headers["content-type"], "application/x-gzip");
-
-    let body = hyper::body::to_bytes(result.body_mut()).await.unwrap();
-    let digest = md5::compute(body);
-    assert_eq!(
-        format!("{:x}", digest),
-        "14ca7578687b016e4633be7fc26fa05e",
+        "3f945ffd0cf39f07d927d8752526caad",
         "md5 digest did not match"
     );
 }

--- a/src/esthri/tests/integration/sync_test.rs
+++ b/src/esthri/tests/integration/sync_test.rs
@@ -27,7 +27,6 @@ fn test_sync_down() {
         source,
         destination,
         filters.as_deref(),
-        #[cfg(feature = "compression")]
         false,
     );
     assert!(res.is_ok(), "s3_sync result: {:?}", res);
@@ -51,7 +50,6 @@ async fn test_sync_down_async() {
         source,
         destination,
         filters.as_deref(),
-        #[cfg(feature = "compression")]
         false,
     )
     .await;
@@ -76,7 +74,6 @@ fn test_sync_down_without_slash() {
         source,
         destination,
         filters.as_deref(),
-        #[cfg(feature = "compression")]
         false,
     );
     assert!(res.is_ok());
@@ -100,7 +97,6 @@ fn test_sync_up_without_slash() {
         source,
         destination,
         filters.as_deref(),
-        #[cfg(feature = "compression")]
         false,
     );
     assert!(res.is_ok());
@@ -124,7 +120,6 @@ fn test_sync_up() {
         source,
         destination,
         filters.as_deref(),
-        #[cfg(feature = "compression")]
         false,
     );
     assert!(res.is_ok());
@@ -148,7 +143,6 @@ async fn test_sync_up_async() {
         source,
         destination,
         filters.as_deref(),
-        #[cfg(feature = "compression")]
         false,
     )
     .await;
@@ -164,14 +158,7 @@ fn test_sync_up_default() {
     let source = S3PathParam::new_local(local_directory);
     let destination = S3PathParam::new_bucket(crate::TEST_BUCKET, s3_key);
 
-    let res = blocking::sync(
-        s3client.as_ref(),
-        source,
-        destination,
-        FILTER_EMPTY,
-        #[cfg(feature = "compression")]
-        false,
-    );
+    let res = blocking::sync(s3client.as_ref(), source, destination, FILTER_EMPTY, false);
     assert!(res.is_ok());
 
     let key_hash_pairs = [
@@ -211,14 +198,7 @@ fn test_sync_down_default() {
     let source = S3PathParam::new_bucket(crate::TEST_BUCKET, s3_key);
     let destination = S3PathParam::new_local(local_directory);
 
-    let res = blocking::sync(
-        s3client.as_ref(),
-        source,
-        destination,
-        FILTER_EMPTY,
-        #[cfg(feature = "compression")]
-        false,
-    );
+    let res = blocking::sync(s3client.as_ref(), source, destination, FILTER_EMPTY, false);
     assert!(res.is_ok());
 
     let key_hash_pairs = [
@@ -249,7 +229,6 @@ fn test_sync_down_filter() {
         source,
         destination,
         filters.as_deref(),
-        #[cfg(feature = "compression")]
         false,
     );
     assert!(res.is_ok());
@@ -279,14 +258,12 @@ async fn test_sync_across() {
         source,
         destination,
         filters.as_deref(),
-        #[cfg(feature = "compression")]
         false,
     )
     .await;
     assert!(res.is_ok(), "s3_sync result: {:?}", res);
 }
 
-#[cfg(feature = "compression")]
 fn sync_test_files_up_compressed(s3client: &rusoto_s3::S3Client, s3_key: &str) -> String {
     let data_dir = "tests/data/sync_up/";
     let temp_data_dir = "sync_up_compressed/";
@@ -306,7 +283,6 @@ fn sync_test_files_up_compressed(s3client: &rusoto_s3::S3Client, s3_key: &str) -
     s3_key.to_string()
 }
 
-#[cfg(feature = "compression")]
 #[test]
 fn test_sync_up_compressed() {
     let s3client = crate::get_s3client();
@@ -331,7 +307,7 @@ fn test_sync_up_compressed() {
 
 /// Test downloading files that were synced up with compression enabled
 /// These should download as the original, uncompressed file
-#[cfg(feature = "compression")]
+
 #[test]
 fn test_sync_down_compressed() {
     let s3client = crate::get_s3client();
@@ -353,7 +329,6 @@ fn test_sync_down_compressed() {
         S3PathParam::new_bucket(crate::TEST_BUCKET, s3_key),
         destination,
         FILTER_EMPTY,
-        #[cfg(feature = "compression")]
         true,
     );
     assert!(res.is_ok());
@@ -369,7 +344,7 @@ fn test_sync_down_compressed() {
 }
 
 /// Test syncing down a mix of compressed and non-compressed files
-#[cfg(feature = "compression")]
+
 #[test]
 fn test_sync_down_compressed_mixed() {
     let s3client = crate::get_s3client();
@@ -393,7 +368,6 @@ fn test_sync_down_compressed_mixed() {
         S3PathParam::new_bucket(crate::TEST_BUCKET, "test_sync_down_mixed_compressed"),
         destination,
         FILTER_EMPTY,
-        #[cfg(feature = "compression")]
         true,
     );
     assert!(res.is_ok());

--- a/src/esthri/tests/integration/upload_test.rs
+++ b/src/esthri/tests/integration/upload_test.rs
@@ -27,7 +27,6 @@ fn test_upload() {
     assert!(!obj_info.metadata.contains_key("esthri_compress_version"));
 }
 
-#[cfg(feature = "compression")]
 #[test]
 fn test_upload_compressed() {
     let s3client = crate::get_s3client();

--- a/src/esthri/tests/integration/upload_test.rs
+++ b/src/esthri/tests/integration/upload_test.rs
@@ -32,7 +32,7 @@ fn test_upload_compressed() {
     let s3client = crate::get_s3client();
     let filename = "27-185232-msg.csv";
     let filepath = format!("tests/data/{}", filename);
-    let s3_key = format!("test_upload/{}.gz", filename);
+    let s3_key = format!("test_upload/{}", filename);
 
     let res =
         blocking::upload_compressed(s3client.as_ref(), crate::TEST_BUCKET, &s3_key, &filepath);


### PR DESCRIPTION
# Design Notes
This is a fairly large change to how esthri handles compression. Previously, esthri would append a suffix of `.gz` to all compressed files on upload, then strip this suffix when decompressing files on download. The main weakness of this is that it was hard to do this in a way that was transparent to the user. If a user were to run `aws cp myfile s3://mybucket/` with compression on then this file would exist on S3 at key `myfile.gz` which meant that when they later ran `aws cp s3://mybucket/myfile` the file wouldn't exist. Changing the filename by appending the `.gz` suffix can also break the use of `--include` and `--exclude` filters.

This changes moves to _not_ changing the filename for compressed files and instead relying on S3 metadata that is added for compressed files in order to tell if they're compressed or not. This method allows users to run commands to download/upload/sync files without needing to be concerned with how the files are represented on S3. The ultimate goal is for users to be able to use esthri without ever knowing (or, really, having to worry about) whether their files are compressed or uncompressed remotely.

As part of this, I've changed some of the nomenclature around "compression" to be "transparent compression" mainly to signify that running with transparent compression in the remote to local direction will transparently decompress files as necessary. Running in the local to remote direction will still compress everything (as before), though it won't replace the source files on local disk.

There's a bunch of subtle changes to how esthri will function after this change:

- Syncing up with compression no longer replaces local files with the compressed versions.
- Compression is no longer behind a feature flag (mainly to let the code be a little more readable.)
- Running `cp` or `sync` with `--compress` (which will be later changed to `--transparent-compression`) to download files should _always_ work to get a decompressed files locally, regardless of whether the files are compressed in S3 or not. esthri will read the metadata to figure out whether it should decompress the file for the user.
- Only files compressed by esthri will be downloaded decompressed (previously any `.gz` file could be decompressed)
- From the HTTP server, compressed files are automatically served with `content-encoding: gzip`. There's no way to access them without this header.
- Download an archive from the HTTP server will add a `.gz` suffix to files within the archive that are compressed. This is to make this functionality more user friendly with the thinking that users wouldn't be relying on the filenames here matching exactly as this is only used for manual downloads - it isn't used in any automation/scripts.

The downside to this change is that a user who is downloading directly from S3 without using esthri (eg with the native `aws` tool or through the S3 console) might be confused as to why their file doesn't match with the file they uploaded. Before rolling this change out we should communicate to users that this is happening and encourage users to use `esthri` for interacting with all SITL data. 

## Todo
Some tasks to finish before this can be merged (but figured I'd open now as a WIP in case there was any feedback):

- [x] Figure out how the HTTP server will work for this change (the compression part is currently broken)
    - To keep the existing implementation, we'd need to run a HEAD on every file being listed in order to figure out if the file is compressed or not. I don't think this is ideal as it will make pages load slower.
    - I think the simplest way of doing this is to remove the ability to download compressed files as "archives" (whic really is just allowing them to be download directly without setting the `content-encoding` header) and instead always serve them with `content-encoding: gzip` if they are compressed.
        - This should still hopefully be fairly transparent to the user, as the browser should do the decompressing. It looks like other common tools like `curl` should be able to support this too (in `curl`s case, you just need to run with `--compressed` to get the uncompressed file down)
- [x] Tidy up the CLI interface
    - I'm thinking to remove the 'esthri' CLI here and to stick with only the AWS compatible CLI, adding in a `--transparent-compression` flag. Could make this smarter about falling back to the 'real' aws tool by only falling back if argv[0] != "aws" or something (though this probably makes sense to do as a separate PR).
    - Also want to add an environment variable that will cause transparent compression to be always on.
    - Also want to add a 'pull in emergency' environment variable switch that gets esthri to always fall back to aws. To aid with a smooth rollout of this feature, I think I will do this in the opposite way first (as in, always fallback unless an env var is specified) so that we can gradually try enabling this in SITL workflows one by one.
- [x] Add some more tests
- [ ] Bump to v7 (once merged)