### PR TITLE
Reduce upload memory usage [DEVINFRA-609]

### DIFF
--- a/src/esthri/Cargo.toml
+++ b/src/esthri/Cargo.toml
@@ -37,6 +37,7 @@ serde = "1"
 serde_derive = "1"
 tempfile = "3.0"
 flate2 = "1.0"
+bytes = "1.0"
 
 [dev-dependencies]
 md5 = "0.7"
@@ -54,7 +55,7 @@ path = "src/lib.rs"
 default = [ "rustls", "cli", "http_server", "blocking",]
 aggressive_lint = []
 blocking = []
-http_server = [ "async-tar", "async-compression", "bytes", "futures-util", "mime_guess", "sluice", "sanitize-filename", "tokio-util", "warp", "ctrlc", "anyhow", "maud",]
+http_server = [ "async-tar", "async-compression", "futures-util", "mime_guess", "sluice", "sanitize-filename", "tokio-util", "warp", "ctrlc", "anyhow", "maud",]
 nativetls = [ "rusoto_credential", "rusoto_core/native-tls", "rusoto_signature", "rusoto_s3/native-tls", "hyper-tls",]
 rustls = [ "rusoto_credential", "rusoto_core/rustls", "rusoto_signature", "rusoto_s3/rustls", "hyper-rustls",]
 cli = [ "ctrlc", "structopt", "blocking", "tokio/rt-multi-thread",]
@@ -124,10 +125,6 @@ optional = true
 
 [dependencies.sluice]
 version = "0.5"
-optional = true
-
-[dependencies.bytes]
-version = "1.0"
 optional = true
 
 [dependencies.tokio-util]

--- a/src/esthri/src/blocking.rs
+++ b/src/esthri/src/blocking.rs
@@ -71,7 +71,7 @@ pub async fn upload_from_reader<T, R>(
 ) -> Result<()>
 where
     T: S3 + Send + Clone,
-    R: Read + Send + 'static,
+    R: Read + Send + Seek + 'static,
 {
     super::upload_from_reader(s3, bucket, key, reader, file_size, None).await
 }

--- a/src/esthri/src/ops/upload.rs
+++ b/src/esthri/src/ops/upload.rs
@@ -265,7 +265,7 @@ where
     (to_read, stream)
 }
 
-fn get_number_of_upload_chunks_for_file_size(file_size: u64) -> u64 {
+fn get_chunk_count(file_size: u64) -> u64 {
     let chunk_size = Config::global().upload_part_size();
 
     // Rounds up as the last chunk may be smaller than the chunk size
@@ -284,7 +284,7 @@ where
     ClientT: S3 + Send + Clone,
     R: bio::Read + Send + bio::Seek + 'static,
 {
-    stream::iter(0..get_number_of_upload_chunks_for_file_size(file_size))
+    stream::iter(0..get_chunk_count(file_size))
         .map(move |chunk_number| {
             let s3 = s3.clone();
             let bucket: String = bucket.clone().into();

--- a/src/esthri/tests/integration/download_test.rs
+++ b/src/esthri/tests/integration/download_test.rs
@@ -36,7 +36,7 @@ fn test_download_to_current_directory() {
     let s3client = crate::get_s3client();
     let filename = "test_file.txt";
     let _tmp_dir = crate::EphemeralTempDir::pushd();
-    let filepath = format!(".");
+    let filepath = ".".to_string();
     let s3_key = format!("test_folder/{}", filename);
 
     let res = blocking::download(s3client.as_ref(), crate::TEST_BUCKET, &s3_key, &filepath);


### PR DESCRIPTION
To have parity with the `aws` tool we currently upload files in 8MiB
chunks, which allows syncs to work consistently between both tools.

However, currently, this causes a large amount of memory use as reads
are read into 8MiB buffers and with a high amount of upload tasks, this
causes large amounts of data to sit waiting in memory to be uploaded.

This change moves to giving a stream that the rustoto upload function
consumes, that means only 1MiB should be read at a time. This reduces
the amount of memory use, especially when esthri is configured to use a
large amount of upload tasks.

--

Hopefully this shouldn't be too hard to merge into @notoriaga's other branch :grinning: 