### PR TITLE
Improvements for low bandwidth connections [DEVINFRA-616]

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -252,20 +252,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cdb031dd78e28731d87d56cc8ffef4a8f36ca26c38fe2de700543e627f8a464a"
 
 [[package]]
-name = "backoff"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b62ddb9cb1ec0a098ad4bbf9344d0713fa193ae1a80af55febcff2627b6a00c1"
-dependencies = [
- "futures-core",
- "getrandom",
- "instant",
- "pin-project-lite",
- "rand 0.8.4",
- "tokio",
-]
-
-[[package]]
 name = "backtrace"
 version = "0.3.64"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -595,7 +581,6 @@ dependencies = [
  "assert_cmd",
  "async-compression",
  "async-stream",
- "backoff",
  "backtrace",
  "bytes",
  "chrono",
@@ -625,6 +610,7 @@ dependencies = [
  "tempfile",
  "thiserror",
  "tokio",
+ "tokio-retry",
  "tokio-util",
  "walkdir",
 ]
@@ -2320,6 +2306,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f7d995660bd2b7f8c1568414c1126076c13fbb725c40112dc0120b78eb9b717b"
 dependencies = [
  "native-tls",
+ "tokio",
+]
+
+[[package]]
+name = "tokio-retry"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f57eb36ecbe0fc510036adff84824dd3c24bb781e21bfa67b69d556aa85214f"
+dependencies = [
+ "pin-project",
+ "rand 0.8.4",
  "tokio",
 ]
 

--- a/crates/esthri/Cargo.toml
+++ b/crates/esthri/Cargo.toml
@@ -20,7 +20,6 @@ rustls = ["rusoto_core/rustls", "rusoto_s3/rustls", "hyper-rustls"]
 [dependencies]
 async-compression = { version = "0.3", features = ["gzip", "tokio"] }
 async-stream = "0.3"
-backoff = { version = "0.4", features = ["tokio"] }
 bytes = "1"
 chrono = "0.4"
 envy = "0.4"
@@ -44,6 +43,7 @@ thiserror = "1"
 tokio = { version = "1", features = ["fs", "io-util", "sync", "parking_lot"] }
 tokio-util = { version = "0.6", features = ["io"] }
 walkdir = "2"
+tokio-retry = "0.3"
 
 [dependencies.hyper-tls]
 version = "0.5"

--- a/crates/esthri/src/config.rs
+++ b/crates/esthri/src/config.rs
@@ -23,16 +23,9 @@ pub const UPLOAD_PART_SIZE: u64 = 8 * 1024 * 1024;
 pub const UPLOAD_READ_SIZE: u64 = 1024 * 1024;
 /// The default number of concurrent tasks run when sending data to S3.
 pub const CONCURRENT_UPLOAD_TASKS: u16 = 8;
-/// When downloading or receiving data from S3, this sizes a task's download buffer.
-pub const DOWNLOAD_BUFFER_SIZE: usize = 8 * 1024 * 1024;
 /// The default number of concurrent tasks run when receiving data from S3.  Each task
 /// represents a connection to S3.
 pub const CONCURRENT_DOWNLOADER_TASKS: u16 = 8;
-/// The default number of concurrent tasks run when receiving compressed data
-/// from S3.  Each task represents a connection to S3.
-pub const CONCURRENT_COMPRESSED_DOWNLOADER_TASKS: u16 = 2;
-/// The default number of concurrent tasks run when writing download data to disk.
-pub const CONCURRENT_WRITER_TASKS: u16 = 64;
 /// The default number of concurrent tasks run when running a sync operation
 pub const CONCURRENT_SYNC_TASKS: u16 = 4;
 /// The default number of times to retry a request if it fails with a transient error.
@@ -48,13 +41,7 @@ pub struct Config {
     #[serde(default)]
     concurrent_upload_tasks: ConcurrentUploadTasks,
     #[serde(default)]
-    download_buffer_size: DownloadBufferSize,
-    #[serde(default)]
     concurrent_downloader_tasks: ConcurrentDownloaderTasks,
-    #[serde(default)]
-    concurrent_compressed_downloader_tasks: ConcurrentCompressedDownloaderTasks,
-    #[serde(default)]
-    concurrent_writer_tasks: ConcurrentWriterTasks,
     #[serde(default)]
     concurrent_sync_tasks: ConcurrentSyncTasks,
     #[serde(default)]
@@ -109,42 +96,6 @@ impl Default for ConcurrentDownloaderTasks {
     }
 }
 
-/// Wrapper type for [CONCURRENT_COMPRESSED_DOWNLOADER_TASKS] which allows
-/// [Config::concurrent_compressed_downloader_tasks()] to bind a default value.
-#[derive(Debug, Deserialize)]
-#[serde(transparent)]
-struct ConcurrentCompressedDownloaderTasks(u16);
-
-impl Default for ConcurrentCompressedDownloaderTasks {
-    fn default() -> Self {
-        ConcurrentCompressedDownloaderTasks(CONCURRENT_COMPRESSED_DOWNLOADER_TASKS)
-    }
-}
-
-/// Wrapper type for [DOWNLOAD_BUFFER_SIZE] which allows [Config::download_buffer_size()] to bind a
-/// default value.
-#[derive(Debug, Deserialize)]
-#[serde(transparent)]
-struct DownloadBufferSize(usize);
-
-impl Default for DownloadBufferSize {
-    fn default() -> Self {
-        DownloadBufferSize(DOWNLOAD_BUFFER_SIZE)
-    }
-}
-
-/// Wrapper type for [CONCURRENT_WRITER_TASKS] which allows [Config::concurrent_writer_tasks()] to
-/// bind a default value.
-#[derive(Debug, Deserialize)]
-#[serde(transparent)]
-struct ConcurrentWriterTasks(u16);
-
-impl Default for ConcurrentWriterTasks {
-    fn default() -> Self {
-        ConcurrentWriterTasks(CONCURRENT_WRITER_TASKS)
-    }
-}
-
 /// Wrapper type for [CONCURRENT_SYNC_TASKS] which allows [Config::concurrent_sync_tasks()] to bind
 /// a default value.
 #[derive(Debug, Deserialize)]
@@ -178,11 +129,10 @@ impl Config {
     /// from the environment:
     ///
     /// - `ESTHRI_UPLOAD_PART_SIZE` - [Config::upload_part_size()]
+    /// - `ESTHRI_UPLOAD_READ_SIZE` - [Config::upload_read_size()]
+    /// - `ESTHRI_CONCURRENT_UPLOAD_TASKS` - [Config::concurrent_upload_tasks()]
     /// - `ESTHRI_CONCURRENT_DOWNLOADER_TASKS` - [Config::concurrent_downloader_tasks()]
-    /// - `ESTHRI_CONCURRENT_COMPRESSED_DOWNLOADER_TASKS` - [Config::concurrent_compressed_downloader_tasks()]
-    /// - `ESTHRI_DOWNLOAD_BUFFER_SIZE` - [Config::download_buffer_size()]
-    /// - `ESTHRI_CONCURRENT_DOWNLOADER_TASKS` - [Config::concurrent_downloader_tasks()]
-    /// - `ESTHRI_CONCURRENT_WRITER_TASKS` - [Config::concurrent_writer_tasks()]
+    /// - `ESTHRI_CONCURRENT_SYNC_TASKS` - [Config::concurrent_sync_tasks()]
     /// - `ESTHRI_REQUEST_RETRIES` - [Config::request_retries()]
     pub fn global() -> &'static Config {
         CONFIG.get_or_init(|| {
@@ -206,34 +156,16 @@ impl Config {
         self.upload_read_size.0
     }
 
-    /// The number of concurrent tasks run when sending data to S3.  Defautls to
+    /// The number of concurrent tasks run when sending data to S3.  Defaults to
     /// [CONCURRENT_UPLOAD_TASKS].
     pub fn concurrent_upload_tasks(&self) -> usize {
         self.concurrent_upload_tasks.0 as usize
-    }
-
-    /// When downloading or receiving data from S3, this sizes a task's download buffer.  Defaults
-    /// to [DOWNLOAD_BUFFER_SIZE].
-    pub fn download_buffer_size(&self) -> usize {
-        self.download_buffer_size.0
     }
 
     /// The number of concurrent tasks run when receiving data from S3.  Each task represents a
     /// connection to S3.  Defaults to [CONCURRENT_DOWNLOADER_TASKS].
     pub fn concurrent_downloader_tasks(&self) -> usize {
         self.concurrent_downloader_tasks.0 as usize
-    }
-
-    /// The number of concurrent tasks run when receiving compressed data from S3.  Each task
-    /// represents a connection to S3.  Defaults to [CONCURRENT_COMPRESSED_DOWNLOADER_TASKS].
-    pub fn concurrent_compressed_downloader_tasks(&self) -> usize {
-        self.concurrent_compressed_downloader_tasks.0 as usize
-    }
-
-    /// The number of concurrent tasks run when writing download data to disk.  Defaults to
-    /// [CONCURRENT_WRITER_TASKS].
-    pub fn concurrent_writer_tasks(&self) -> usize {
-        self.concurrent_writer_tasks.0 as usize
     }
 
     /// The number of concurrent tasks run when running a sync operation.  Defaults to

--- a/crates/esthri/src/config.rs
+++ b/crates/esthri/src/config.rs
@@ -22,19 +22,19 @@ pub const UPLOAD_PART_SIZE: u64 = 8 * 1024 * 1024;
 /// The default amount of data to read out of a file at a time.
 pub const UPLOAD_READ_SIZE: u64 = 1024 * 1024;
 /// The default number of concurrent tasks run when sending data to S3.
-pub const CONCURRENT_UPLOAD_TASKS: u16 = 16;
+pub const CONCURRENT_UPLOAD_TASKS: u16 = 8;
 /// When downloading or receiving data from S3, this sizes a task's download buffer.
 pub const DOWNLOAD_BUFFER_SIZE: usize = 8 * 1024 * 1024;
 /// The default number of concurrent tasks run when receiving data from S3.  Each task
 /// represents a connection to S3.
-pub const CONCURRENT_DOWNLOADER_TASKS: u16 = 32;
+pub const CONCURRENT_DOWNLOADER_TASKS: u16 = 8;
 /// The default number of concurrent tasks run when receiving compressed data
 /// from S3.  Each task represents a connection to S3.
 pub const CONCURRENT_COMPRESSED_DOWNLOADER_TASKS: u16 = 2;
 /// The default number of concurrent tasks run when writing download data to disk.
 pub const CONCURRENT_WRITER_TASKS: u16 = 64;
 /// The default number of concurrent tasks run when running a sync operation
-pub const CONCURRENT_SYNC_TASKS: u16 = 16;
+pub const CONCURRENT_SYNC_TASKS: u16 = 4;
 /// The default number of times to retry a request if it fails with a transient error.
 pub const REQUEST_RETRIES: u16 = 5;
 

--- a/crates/esthri/src/ops/sync.rs
+++ b/crates/esthri/src/ops/sync.rs
@@ -29,6 +29,7 @@ use crate::{
     errors::{Error, Result},
     handle_dispatch_error, list_objects_stream,
     rusoto::*,
+    tempfile::TEMP_FILE_PREFIX,
     types::ListingMetadata,
     types::{S3ListingItem, S3PathParam},
 };
@@ -177,6 +178,9 @@ fn create_dirent_stream<'a>(
                 yield Err(entry.err().unwrap().into());
                 return;
             };
+            if entry.file_name().to_string_lossy().contains(TEMP_FILE_PREFIX) {
+                continue;
+            }
             let metadata = entry.metadata();
             let stat = if let Ok(stat) = metadata {
                 stat

--- a/crates/esthri/src/retry.rs
+++ b/crates/esthri/src/retry.rs
@@ -10,13 +10,15 @@
  * WARRANTIES OF MERCHANTABILITY AND/OR FITNESS FOR A PARTICULAR PURPOSE.
  */
 
+use futures::Future;
+use log::warn;
 use std::time::Duration;
 
-use backoff::ExponentialBackoff;
-use futures::Future;
-use log::debug;
+use tokio_retry::strategy::{jitter, ExponentialBackoff};
+use tokio_retry::RetryIf;
 
 use crate::rusoto::{RusotoError, RusotoResult};
+use crate::Config;
 
 pub async fn handle_dispatch_error<'a, F, R, T, E>(func: F) -> RusotoResult<T, E>
 where
@@ -24,32 +26,27 @@ where
     R: Future<Output = RusotoResult<T, E>>,
     E: std::error::Error,
 {
-    backoff::future::retry(default_backoff(), || async {
-        func().await.map_err(from_rusoto_err::<E>)
-    })
-    .await
+    let retry_strategy = ExponentialBackoff::from_millis(500)
+        .max_delay(Duration::from_secs(10))
+        .map(jitter)
+        .take(Config::global().request_retries());
+
+    RetryIf::spawn(retry_strategy, func, is_transient_err).await
 }
 
-fn from_rusoto_err<E>(err: RusotoError<E>) -> backoff::Error<RusotoError<E>> {
-    use backoff::Error;
-
+fn is_transient_err<E>(err: &RusotoError<E>) -> bool {
     match err {
-        RusotoError::HttpDispatch(_) => {
-            debug!("Retrying S3 dispatch error");
-            Error::transient(err)
+        RusotoError::HttpDispatch(ref res) => {
+            warn!("Retrying S3 dispatch error {}", res);
+            true
         }
         RusotoError::Unknown(ref res) if res.status.is_server_error() => {
-            debug!("Retrying S3 server error: {}", res.body_as_str());
-            Error::transient(err)
+            warn!("Retrying S3 server error: {}", res.body_as_str());
+            false
         }
-        _ => Error::Permanent(err),
-    }
-}
-
-fn default_backoff() -> ExponentialBackoff {
-    ExponentialBackoff {
-        max_interval: Duration::from_secs(10),
-        max_elapsed_time: Some(Duration::from_secs(45)),
-        ..Default::default()
+        _ => {
+            warn!("Permanent error, not retrying");
+            false
+        }
     }
 }

--- a/crates/esthri/src/retry.rs
+++ b/crates/esthri/src/retry.rs
@@ -42,7 +42,7 @@ fn is_transient_err<E>(err: &RusotoError<E>) -> bool {
         }
         RusotoError::Unknown(ref res) if res.status.is_server_error() => {
             warn!("Retrying S3 server error: {}", res.body_as_str());
-            false
+            true
         }
         _ => {
             warn!("Permanent error, not retrying");

--- a/crates/esthri/src/retry.rs
+++ b/crates/esthri/src/retry.rs
@@ -11,7 +11,7 @@
  */
 
 use futures::Future;
-use log::{error, warn};
+use log::warn;
 use std::time::Duration;
 
 use tokio_retry::strategy::{jitter, ExponentialBackoff};
@@ -45,7 +45,6 @@ fn is_transient_err<E>(err: &RusotoError<E>) -> bool {
             true
         }
         _ => {
-            error!("Permanent error, not retrying");
             false
         }
     }

--- a/crates/esthri/src/retry.rs
+++ b/crates/esthri/src/retry.rs
@@ -44,8 +44,6 @@ fn is_transient_err<E>(err: &RusotoError<E>) -> bool {
             warn!("Transient S3 server error: {}", res.body_as_str());
             true
         }
-        _ => {
-            false
-        }
+        _ => false,
     }
 }

--- a/crates/esthri/src/retry.rs
+++ b/crates/esthri/src/retry.rs
@@ -11,7 +11,7 @@
  */
 
 use futures::Future;
-use log::warn;
+use log::{error, warn};
 use std::time::Duration;
 
 use tokio_retry::strategy::{jitter, ExponentialBackoff};
@@ -37,15 +37,15 @@ where
 fn is_transient_err<E>(err: &RusotoError<E>) -> bool {
     match err {
         RusotoError::HttpDispatch(ref res) => {
-            warn!("Retrying S3 dispatch error {}", res);
+            warn!("Transient S3 dispatch error {}", res);
             true
         }
         RusotoError::Unknown(ref res) if res.status.is_server_error() => {
-            warn!("Retrying S3 server error: {}", res.body_as_str());
+            warn!("Transient S3 server error: {}", res.body_as_str());
             true
         }
         _ => {
-            warn!("Permanent error, not retrying");
+            error!("Permanent error, not retrying");
             false
         }
     }

--- a/crates/esthri/src/tempfile.rs
+++ b/crates/esthri/src/tempfile.rs
@@ -16,12 +16,14 @@ pub struct TempFile {
     file: Option<File>,
 }
 
+pub const TEMP_FILE_PREFIX: &str = ".esthri_temp";
+
 impl TempFile {
     pub async fn new(dir: PathBuf, suffix: Option<&str>) -> Result<Self> {
         let suffix = suffix.unwrap_or_default().to_owned();
         let path = task::spawn_blocking(move || {
             let f = tempfile::Builder::new()
-                .prefix(".esthri_temp.")
+                .prefix(TEMP_FILE_PREFIX)
                 .suffix(&suffix)
                 .tempfile_in(dir)?;
             Result::Ok(f.into_temp_path())


### PR DESCRIPTION
- Changes retry to terminate after 5 attempts (have made the number of attempts configurable too), rather than after 45 seconds
- Lowers the default tasks amounts
- Cleanup of some now unused config options