### PR TITLE
Don't publish CLI and test crates

### DIFF
--- a/crates/esthri-cli/release.toml
+++ b/crates/esthri-cli/release.toml
@@ -1,0 +1,1 @@
+publish = false

--- a/crates/esthri-test/release.toml
+++ b/crates/esthri-test/release.toml
@@ -1,0 +1,1 @@
+publish = false


### PR DESCRIPTION
Tell `cargo release` not to publish these crates. Only the main esthri
library crate needs to be published.