### PR TITLE
Fix sync up and improve upload tests [DEVINFRA-629]

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -664,6 +664,7 @@ dependencies = [
  "md5",
  "once_cell",
  "tempdir",
+ "uuid",
 ]
 
 [[package]]
@@ -2526,6 +2527,15 @@ name = "utf-8"
 version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09cc8ee72d2a9becf2f2febe0205bbed8fc6615b7cb429ad062dc7b7ddd036a9"
+
+[[package]]
+name = "uuid"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bc5cf98d8186244414c848017f0e2676b3fcb46807f6668a97dfe67359a3c4b7"
+dependencies = [
+ "getrandom",
+]
 
 [[package]]
 name = "value-bag"

--- a/crates/esthri-test/Cargo.toml
+++ b/crates/esthri-test/Cargo.toml
@@ -17,3 +17,4 @@ hyper = "0.14"
 md5 = "0.7"
 once_cell = "1.7"
 tempdir = "0.3"
+uuid = { version="0.8.2", features=["v4"]}

--- a/crates/esthri-test/src/lib.rs
+++ b/crates/esthri-test/src/lib.rs
@@ -12,6 +12,7 @@ use tempdir::TempDir;
 
 use esthri::rusoto::*;
 use esthri::*;
+use uuid::Uuid;
 
 pub struct TestGlobal {
     s3client: Option<Arc<S3Client>>,
@@ -28,6 +29,10 @@ pub type DateTime = chrono::DateTime<chrono::Utc>;
 
 pub fn test_data(name: &str) -> PathBuf {
     test_data_dir().join(name)
+}
+
+pub fn randomised_name(name: &str) -> String {
+    format!("{}-{}", Uuid::new_v4(), name)
 }
 
 pub fn test_data_dir() -> PathBuf {

--- a/crates/esthri/tests/integration/sync_test.rs
+++ b/crates/esthri/tests/integration/sync_test.rs
@@ -58,7 +58,7 @@ async fn test_sync_down_async() {
 fn test_sync_down_without_slash() {
     let s3client = esthri_test::get_s3client();
     let local_directory = esthri_test::test_data_dir();
-    let s3_key = "test_folder";
+    let s3_key = esthri_test::randomised_name("test_folder");
     let filters: Option<Vec<GlobFilter>> = Some(vec![
         GlobFilter::Include(Pattern::new("*.txt").unwrap()),
         GlobFilter::Exclude(Pattern::new("*").unwrap()),
@@ -81,7 +81,7 @@ fn test_sync_down_without_slash() {
 fn test_sync_up_without_slash() {
     let s3client = esthri_test::get_s3client();
     let local_directory = esthri_test::test_data_dir();
-    let s3_key = "test_folder";
+    let s3_key = esthri_test::randomised_name("test_folder");
     let filters: Option<Vec<GlobFilter>> = Some(vec![
         GlobFilter::Include(Pattern::new("*.txt").unwrap()),
         GlobFilter::Exclude(Pattern::new("*").unwrap()),
@@ -104,7 +104,7 @@ fn test_sync_up_without_slash() {
 fn test_sync_up() {
     let s3client = esthri_test::get_s3client();
     let local_directory = esthri_test::test_data_dir();
-    let s3_key = "test_folder/";
+    let s3_key = esthri_test::randomised_name("test_folder/");
     let filters: Option<Vec<GlobFilter>> = Some(vec![
         GlobFilter::Include(Pattern::new("*.txt").unwrap()),
         GlobFilter::Exclude(Pattern::new("*").unwrap()),
@@ -127,7 +127,7 @@ fn test_sync_up() {
 async fn test_sync_up_async() {
     let s3client = esthri_test::get_s3client();
     let local_directory = esthri_test::test_data_dir();
-    let s3_key = "test_folder/";
+    let s3_key = esthri_test::randomised_name("test_folder/");
     let filters: Option<Vec<GlobFilter>> = Some(vec![
         GlobFilter::Include(Pattern::new("*.txt").unwrap()),
         GlobFilter::Exclude(Pattern::new("*").unwrap()),
@@ -151,10 +151,10 @@ async fn test_sync_up_async() {
 fn test_sync_up_default() {
     let s3client = esthri_test::get_s3client();
     let local_directory = esthri_test::test_data("sync_up");
-    let s3_key = "test_sync_up_default/";
+    let s3_key = esthri_test::randomised_name("test_sync_up_default/");
 
     let source = S3PathParam::new_local(&local_directory);
-    let destination = S3PathParam::new_bucket(esthri_test::TEST_BUCKET, s3_key);
+    let destination = S3PathParam::new_bucket(esthri_test::TEST_BUCKET, &s3_key);
 
     let res = blocking::sync(s3client.as_ref(), source, destination, FILTER_EMPTY, false);
     assert!(res.is_ok());
@@ -167,7 +167,7 @@ fn test_sync_up_default() {
     ];
 
     for key_hash_pair in &key_hash_pairs[..] {
-        let key = format!("{}{}", s3_key, key_hash_pair.0);
+        let key = format!("{}{}", &s3_key, key_hash_pair.0);
         let res = blocking::head_object(s3client.as_ref(), esthri_test::TEST_BUCKET, &key);
         assert!(res.is_ok(), "fetching s3 etag failed for: {}", key);
         let res = res.unwrap();
@@ -243,7 +243,7 @@ fn test_sync_down_filter() {
 async fn test_sync_across() {
     let s3client = esthri_test::get_s3client();
     let source_prefix = "test_sync_folder1/";
-    let dest_prefix = "test_sync_folder2/";
+    let dest_prefix = esthri_test::randomised_name("test_sync_folder2/");
 
     let filters: Option<Vec<GlobFilter>> =
         Some(vec![GlobFilter::Include(Pattern::new("*.txt").unwrap())]);
@@ -284,13 +284,14 @@ fn sync_test_files_up_compressed(s3client: &rusoto_s3::S3Client, s3_key: &str) -
 #[test]
 fn test_sync_up_compressed() {
     let s3client = esthri_test::get_s3client();
-    let s3_key = sync_test_files_up_compressed(s3client.as_ref(), "test_sync_up_compressed/");
+    let key = esthri_test::randomised_name("test_sync_up_compressed/");
+    let s3_key = sync_test_files_up_compressed(s3client.as_ref(), &key);
 
     let key_hash_pairs = [
-        KeyHashPair("1-one.data.gz", "\"276ebe187bb53cb68e484e8c0c0fef68\""),
-        KeyHashPair("2-two.bin.gz", "\"2b08f95817755fc00c1cc1e528dc7db8\""),
-        KeyHashPair("3-three.junk.gz", "\"12bc292b0d53b61203b839588213a9a1\""),
-        KeyHashPair("nested/2MiB.bin.gz", "\"da4b426cae11741846271040d9b4dc71\""),
+        KeyHashPair("1-one.data", "\"276ebe187bb53cb68e484e8c0c0fef68\""),
+        KeyHashPair("2-two.bin", "\"2b08f95817755fc00c1cc1e528dc7db8\""),
+        KeyHashPair("3-three.junk", "\"12bc292b0d53b61203b839588213a9a1\""),
+        KeyHashPair("nested/2MiB.bin", "\"da4b426cae11741846271040d9b4dc71\""),
     ];
 
     for key_hash_pair in &key_hash_pairs[..] {
@@ -309,9 +310,9 @@ fn test_sync_up_compressed() {
 #[test]
 fn test_sync_down_compressed() {
     let s3client = esthri_test::get_s3client();
-    let s3_key = "test_sync_down_compressed_v7/";
+    let s3_key = esthri_test::randomised_name("test_sync_down_compressed_v7/");
 
-    sync_test_files_up_compressed(s3client.as_ref(), s3_key);
+    sync_test_files_up_compressed(s3client.as_ref(), &s3_key);
 
     let local_directory = esthri_test::test_data("sync_down/d");
     let sync_dir_meta = fs::metadata(&local_directory);
@@ -346,19 +347,19 @@ fn test_sync_down_compressed() {
 #[test]
 fn test_sync_down_compressed_mixed() {
     let s3client = esthri_test::get_s3client();
-    let s3_key = "test_sync_down_compressed_mixed_v7/";
+    let s3_key = esthri_test::randomised_name("test_sync_down_compressed_mixed_v7/");
 
     blocking::upload(
         s3client.as_ref(),
         esthri_test::TEST_BUCKET,
-        s3_key,
+        &s3_key,
         esthri_test::test_data("index.html"),
     )
     .unwrap();
     blocking::upload_compressed(
         s3client.as_ref(),
         esthri_test::TEST_BUCKET,
-        s3_key,
+        &s3_key,
         esthri_test::test_data("test_file.txt"),
     )
     .unwrap();
@@ -378,7 +379,7 @@ fn test_sync_down_compressed_mixed() {
 
         let res = blocking::sync(
             s3client.as_ref(),
-            S3PathParam::new_bucket(esthri_test::TEST_BUCKET, s3_key),
+            S3PathParam::new_bucket(esthri_test::TEST_BUCKET, &s3_key),
             destination,
             FILTER_EMPTY,
             false,
@@ -406,7 +407,7 @@ fn test_sync_down_compressed_mixed() {
 
         let res = blocking::sync(
             s3client.as_ref(),
-            S3PathParam::new_bucket(esthri_test::TEST_BUCKET, s3_key),
+            S3PathParam::new_bucket(esthri_test::TEST_BUCKET, &s3_key),
             destination,
             FILTER_EMPTY,
             true,

--- a/crates/esthri/tests/integration/upload_test.rs
+++ b/crates/esthri/tests/integration/upload_test.rs
@@ -10,7 +10,7 @@ fn test_upload() {
     let s3client = esthri_test::get_s3client();
     let filename = "test5mb.bin";
     let filepath = esthri_test::test_data(filename);
-    let s3_key = format!("test_upload/{}", filename);
+    let s3_key = esthri_test::randomised_name(&format!("test_upload/{}", filename));
 
     let res = esthri::blocking::upload(
         s3client.as_ref(),
@@ -35,7 +35,7 @@ fn test_upload_compressed() {
     let s3client = esthri_test::get_s3client();
     let filename = "27-185232-msg.csv";
     let filepath = esthri_test::test_data(filename);
-    let s3_key = format!("test_upload/{}", filename);
+    let s3_key = esthri_test::randomised_name(&format!("test_upload/{}", filename));
 
     let res = esthri::blocking::upload_compressed(
         s3client.as_ref(),
@@ -65,7 +65,7 @@ async fn test_upload_async() {
     let s3client = esthri_test::get_s3client();
     let filename = "test5mb.bin";
     let filepath = esthri_test::test_data(filename);
-    let s3_key = format!("test_upload/{}", filename);
+    let s3_key = esthri_test::randomised_name(&format!("test_upload/{}", filename));
 
     let res = upload(
         s3client.as_ref(),
@@ -81,7 +81,7 @@ async fn test_upload_async() {
 async fn test_upload_reader() {
     let s3client = esthri_test::get_s3client();
     let filename = "test_reader_upload.bin";
-    let filepath = format!("test_upload_reader/{}", filename);
+    let filepath = esthri_test::randomised_name(&format!("test_upload_reader/{}", filename));
     let contents = "file contents";
     let reader = Cursor::new(contents);
 
@@ -102,7 +102,7 @@ fn test_upload_zero_size() {
     let s3client = esthri_test::get_s3client();
     let filename = "test0b.bin";
     let filepath = esthri_test::test_data(filename);
-    let s3_key = format!("test_upload_zero_size/{}", filename);
+    let s3_key = esthri_test::randomised_name(&format!("test_upload_zero_size/{}", filename));
 
     let res = blocking::upload(
         s3client.as_ref(),


### PR DESCRIPTION
- Upload keys have been randomised to make the tests actually check if
files have been uploaded. Previously these tests were effectively only
testing if the files that had already been uploaded hasn't changed,
which doesn't catch issues with the upload not occurring.

- Fixes the walk dir blocking thread not being spawned as it was being
given an async closure. Also makes directories not get emitted.