### PR TITLE
Allow number of concurrent writers to be configurable [DEVINFRA-631]

### DIFF
--- a/crates/esthri/src/ops/download.rs
+++ b/crates/esthri/src/ops/download.rs
@@ -123,7 +123,7 @@ where
                 }
                 Result::Ok(())
             })
-            .try_buffer_unordered(Config::global().concurrent_downloader_tasks());
+            .try_buffer_unordered(Config::global().concurrent_writer_tasks());
         let _: () = stream.try_collect().await?;
     };
 


### PR DESCRIPTION
Adds config to set the number of concurrent writers and sets it to 1.
This seems to make esthri less aggressive in terms of using lots of
memory to hold pending file writes.

Can see in the plots below that with this change it looks like the system is at max memory usage for a lower amount of time, at the expense of a small bit of speed. I think this makes sense as, with this change, esthri will basically become blocked and wait for the `write` to become unblocked  before downloading anything more. Whereas, without this change, esthri is very eager to keep going despite any individual writer being blocked.

### With concurrent writers == 4
![image](https://user-images.githubusercontent.com/3880246/153533018-0ead6aa3-9051-4af1-a93c-6b4edea67ef1.png)


### With concurrent writers == 1
![image](https://user-images.githubusercontent.com/3880246/153532966-94776ab2-e60b-4af1-9f1c-fd058dd9561e.png)
