### PR TITLE
use system temp dir

### DIFF
--- a/crates/esthri/src/compression.rs
+++ b/crates/esthri/src/compression.rs
@@ -25,17 +25,13 @@ pub const ESTHRI_METADATA_COMPRESS_KEY: &str = "esthri_compress_version";
 
 pub async fn compress_to_tempfile(path: &Path) -> Result<(TempFile, u64)> {
     debug!("compressing: {}", path.display());
-    let dir = match path.parent() {
-        Some(parent) => parent.to_owned(),
-        None => std::env::current_dir()?,
-    };
     let mut src = {
         let f = File::open(path).await?;
         let size = f.metadata().await?.len();
         debug!("old file size: {}", size);
         GzipEncoder::new(BufReader::new(f))
     };
-    let mut dest = TempFile::new(dir, Some(".gz")).await?;
+    let mut dest = TempFile::new(Some(".gz")).await?;
     let new_size = io::copy(&mut src, dest.file_mut()).await?;
     dest.rewind().await?;
     debug!("new file size: {}", new_size);

--- a/crates/esthri/src/ops/download.rs
+++ b/crates/esthri/src/ops/download.rs
@@ -102,8 +102,8 @@ where
         obj_info.size,
         obj_info.parts * obj_info.size as u64
     );
-    let dir = init_download_dir(download_path).await?;
-    let mut dest = TempFile::new(dir, None).await?;
+    init_download_dir(download_path).await?;
+    let mut dest = TempFile::new(None).await?;
 
     if transparent_decompression && obj_info.is_esthri_compressed() {
         let stream = download_streaming_helper(s3, bucket, key, obj_info.parts);
@@ -175,7 +175,7 @@ where
         .map_ok(|res| (res.part, res.into_stream()))
 }
 
-async fn init_download_dir(path: &Path) -> Result<PathBuf> {
+async fn init_download_dir(path: &Path) -> Result<()> {
     let mut path = path.to_owned();
     tokio::task::spawn_blocking(move || {
         if !path.is_file() && !path.is_dir() {
@@ -191,11 +191,8 @@ async fn init_download_dir(path: &Path) -> Result<PathBuf> {
                 info!("Creating directory path {:?}", dir.as_os_str());
                 std::fs::create_dir_all(&dir)?;
             }
-            Ok(dir)
-        } else {
-            path.pop();
-            Ok(path)
         }
+        Ok(())
     })
     .await?
 }

--- a/crates/esthri/src/ops/download.rs
+++ b/crates/esthri/src/ops/download.rs
@@ -10,7 +10,7 @@
  * WARRANTIES OF MERCHANTABILITY AND/OR FITNESS FOR A PARTICULAR PURPOSE.
  */
 
-use std::path::{Path, PathBuf};
+use std::path::Path;
 use std::sync::Arc;
 
 use async_compression::tokio::write::GzipDecoder;

--- a/crates/esthri/src/tempfile.rs
+++ b/crates/esthri/src/tempfile.rs
@@ -19,13 +19,13 @@ pub struct TempFile {
 pub const TEMP_FILE_PREFIX: &str = ".esthri_temp";
 
 impl TempFile {
-    pub async fn new(dir: PathBuf, suffix: Option<&str>) -> Result<Self> {
+    pub async fn new(suffix: Option<&str>) -> Result<Self> {
         let suffix = suffix.unwrap_or_default().to_owned();
         let path = task::spawn_blocking(move || {
             let f = tempfile::Builder::new()
                 .prefix(TEMP_FILE_PREFIX)
                 .suffix(&suffix)
-                .tempfile_in(dir)?;
+                .tempfile()?;
             Result::Ok(f.into_temp_path())
         })
         .await??;


### PR DESCRIPTION
Found a race condition where temp files weren't cleaned up quick enough after a download and some other code that walked the download dir picked up the temp files. This uses the system temp dir instead of the pwd. This also means that should some code panic (or you ctrl-c the bin) the files will still be cleaned up (because the os handles the cleanup now)