### PR TITLE
Defaults to config storage class

### DIFF
--- a/crates/esthri/src/ops/upload.rs
+++ b/crates/esthri/src/ops/upload.rs
@@ -212,7 +212,7 @@ where
         key.as_ref(),
         file.as_ref(),
         compressed,
-        S3StorageClass::StandardIA,
+        Config::global().storage_class(),
     )
     .await
 }
@@ -237,7 +237,7 @@ where
         reader,
         file_size,
         metadata,
-        S3StorageClass::StandardIA,
+        Config::global().storage_class(),
     )
     .await
 }

--- a/crates/esthri/tests/integration/upload_test.rs
+++ b/crates/esthri/tests/integration/upload_test.rs
@@ -56,6 +56,7 @@ fn test_upload_compressed() {
 
     assert_eq!(obj_info.size, 3344161);
     assert_eq!(obj_info.e_tag, "\"4a57bdf6ed65bc7e9ed34a4796561f06\"");
+    assert_eq!(obj_info.storage_class, S3StorageClass::Standard);
     assert_eq!(
         obj_info.metadata.get("esthri_compress_version").unwrap(),
         env!("CARGO_PKG_VERSION")


### PR DESCRIPTION
Missed `upload_compressed` which defaulted to standardIA instead of config