### PR TITLE
Removing CommandExt

### DIFF
--- a/crates/esthri-cli/src/main.rs
+++ b/crates/esthri-cli/src/main.rs
@@ -227,10 +227,10 @@ fn call_real_aws() {
     let aws_tool_path = env::var(REAL_AWS_EXECUTABLE_ENV_NAME)
         .unwrap_or_else(|_| REAL_AWS_EXECUTABLE_DEFAULT.to_string());
 
-    Command::new(&aws_tool_path)
+    let status = Command::new(&aws_tool_path)
         .args(args)
         .stdout(Stdio::inherit())
-        .output()
+        .status()
         .expect(
             format!(
                 "Executing aws didn't work. Is it installed and available as {:?} ",
@@ -238,6 +238,7 @@ fn call_real_aws() {
             )
             .as_str(),
         );
+    std::process::exit(status.code().unwrap_or(-1));
 }
 
 /// Checks if the Esthri CLI tool should run in "aws compatibility mode", where

--- a/crates/esthri-cli/src/main.rs
+++ b/crates/esthri-cli/src/main.rs
@@ -15,9 +15,8 @@ mod http_server;
 
 use std::env;
 use std::ffi::OsStr;
-use std::os::unix::process::CommandExt;
 use std::path::{Path, PathBuf};
-use std::process::Command;
+use std::process::{Command, Stdio};
 use std::time::Duration;
 
 use anyhow::Result;
@@ -228,12 +227,17 @@ fn call_real_aws() {
     let aws_tool_path = env::var(REAL_AWS_EXECUTABLE_ENV_NAME)
         .unwrap_or_else(|_| REAL_AWS_EXECUTABLE_DEFAULT.to_string());
 
-    let err = Command::new(&aws_tool_path).args(args).exec();
-
-    panic!(
-        "Executing aws didn't work. Is it installed and available as {:?}? {:?}",
-        aws_tool_path, err
-    );
+    Command::new(&aws_tool_path)
+        .args(args)
+        .stdout(Stdio::inherit())
+        .output()
+        .expect(
+            format!(
+                "Executing aws didn't work. Is it installed and available as {:?} ",
+                aws_tool_path
+            )
+            .as_str(),
+        );
 }
 
 /// Checks if the Esthri CLI tool should run in "aws compatibility mode", where


### PR DESCRIPTION
CommandExt only supports unix:
https://doc.rust-lang.org/std/os/unix/process/trait.CommandExt.html

Building on windows fails in #305, needs to use windows...
https://doc.rust-lang.org/std/os/windows/process/trait.CommandExt.html

so maybe i took out the commandext overall but the output does not return success code of msg so might have to remove `.success()` in all the cli tests?