### PR TITLE
Allow esthri-cli crate to be published.

### DIFF
--- a/crates/esthri-cli/release.toml
+++ b/crates/esthri-cli/release.toml
@@ -1,1 +1,0 @@
-publish = false


### PR DESCRIPTION
Not entirely sure if the release.toml in the root will handle both crates or if we need to provide a separate release.toml for both? Seems like everything is abstracted though so maybe this is fine.

fixes https://github.com/swift-nav/esthri/issues/277