### PR TITLE
Specify path and version esthri-cli.

### DIFF
--- a/crates/esthri-cli/Cargo.toml
+++ b/crates/esthri-cli/Cargo.toml
@@ -26,7 +26,7 @@ name = "esthri_server"
 path = "src/http_server.rs"
 
 [dependencies]
-esthri = { path = "../esthri", default-features = false }
+esthri = { version = "8.4.0", path = "../esthri", default-features = false }
 anyhow = { version = "1", features = ["backtrace"] }
 async-compression = { version = "0.3", features = ["gzip", "tokio"] }
 async_zip = "0.0.7"


### PR DESCRIPTION
AFAICT this will refer to the local reference path when making changes locally but when we run `cargo release`, it will uprev the version to the new esthri version and use that when compiling esthri-cli.

```
jm@ubuntu:~/dev/esthri$ cargo release --workspace 8.5.1 --verbose
[2022-08-30T20:35:22Z DEBUG cargo_release::release] Files changed in esthri since 8.4.0: [
        "/home/jm/dev/esthri/crates/esthri/Cargo.toml",
        "/home/jm/dev/esthri/crates/esthri/src/lib.rs",
    ]
[2022-08-30T20:35:22Z DEBUG cargo_release::release] Files changed in esthri-test since 8.4.0: [
        "/home/jm/dev/esthri/crates/esthri-test/Cargo.toml",
        "/home/jm/dev/esthri/crates/esthri-test/src/lib.rs",
    ]
[2022-08-30T20:35:22Z DEBUG cargo_release::release] Files changed in esthri-cli since 8.4.0: [
        "/home/jm/dev/esthri/crates/esthri-cli/Cargo.toml",
    ]
[2022-08-30T20:35:22Z DEBUG globset] built glob set; 0 literals, 1 basenames, 0 extensions, 0 prefixes, 0 suffixes, 0 required extensions, 0 regexes
[2022-08-30T20:35:22Z ERROR cargo_release::release] Cannot release from branch "john-michaelburke/fix-esthri-cli", instead switch to "master"
[2022-08-30T20:35:23Z INFO  cargo_release::release] Update esthri to version 8.5.1
[2022-08-30T20:35:23Z DEBUG cargo_release::cargo] Change:
    --- /home/jm/dev/esthri/crates/esthri/Cargo.toml	original
    +++ /home/jm/dev/esthri/crates/esthri/Cargo.toml	updated
    @@ -4 +4 @@
    -version = "8.4.0"
    +version = "8.5.1"
    
[2022-08-30T20:35:23Z DEBUG cargo_release::release] Updating lock file
[2022-08-30T20:35:23Z INFO  cargo_release::release] Update esthri-test to version 8.5.1
[2022-08-30T20:35:23Z DEBUG cargo_release::cargo] Change:
    --- /home/jm/dev/esthri/crates/esthri-test/Cargo.toml	original
    +++ /home/jm/dev/esthri/crates/esthri-test/Cargo.toml	updated
    @@ -3 +3 @@
    -version = "8.4.0"
    +version = "8.5.1"
    
[2022-08-30T20:35:23Z DEBUG cargo_release::release] Updating lock file
[2022-08-30T20:35:23Z INFO  cargo_release::release] Update esthri-cli to version 8.5.1
[2022-08-30T20:35:23Z DEBUG cargo_release::cargo] Change:
    --- /home/jm/dev/esthri/crates/esthri-cli/Cargo.toml	original
    +++ /home/jm/dev/esthri/crates/esthri-cli/Cargo.toml	updated
    @@ -4 +4 @@
    -version = "8.4.0"
    +version = "8.5.1"
    
[2022-08-30T20:35:23Z DEBUG cargo_release::release] Updating lock file
[2022-08-30T20:35:23Z INFO  cargo_release::release] Publishing esthri
[2022-08-30T20:35:23Z DEBUG cargo_release::release] Skipping verification to avoid unpublished dependencies from dry-run
    Updating crates.io index
   Packaging esthri v8.4.0 (/home/jm/dev/esthri/crates/esthri)
   Uploading esthri v8.4.0 (/home/jm/dev/esthri/crates/esthri)
warning: aborting upload due to dry run
[2022-08-30T20:35:23Z INFO  cargo_release::release] Publishing esthri-cli
[2022-08-30T20:35:23Z DEBUG cargo_release::release] Skipping verification to avoid unpublished dependencies from dry-run
    Updating crates.io index
   Packaging esthri-cli v8.4.0 (/home/jm/dev/esthri/crates/esthri-cli)
   Uploading esthri-cli v8.4.0 (/home/jm/dev/esthri/crates/esthri-cli)
warning: aborting upload due to dry run
[2022-08-30T20:35:24Z DEBUG cargo_release::release] Creating git tag 8.5.1
[2022-08-30T20:35:24Z INFO  cargo_release::release] Pushing 8.5.1, john-michaelburke/fix-esthri-cli to origin
[2022-08-30T20:35:24Z ERROR cargo_release::release] Dry-run failed, resolve the above errors and try again.
jm@ubuntu:~/dev/esthri$ 


```