### PR TITLE
esthri-cli: serve: add support for configuring a list of allowed prefixes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,3 @@
-/target
+target/
 **/*.rs.bk
 .*.sw?

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -312,16 +312,16 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "3.2.2"
+version = "3.2.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e538f9ee5aa3b3963f09a997035f883677966ed50fce0292611927ce6f6d8c6"
+checksum = "23b71c3ce99b7611011217b366d923f1d0a7e07a92bb2dbf1e84508c673ca3bd"
 dependencies = [
  "atty",
  "bitflags",
  "clap_derive",
  "clap_lex",
  "indexmap",
- "lazy_static",
+ "once_cell",
  "strsim 0.10.0",
  "termcolor",
  "textwrap",
@@ -329,9 +329,9 @@ dependencies = [
 
 [[package]]
 name = "clap_derive"
-version = "3.2.2"
+version = "3.2.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a7f98063cac4652f23ccda556b8d04347a7fc4b2cff1f7577cc8c6546e0d8078"
+checksum = "ea0c8bce528c4be4da13ea6fead8965e95b6073585a2f05204bd8f4119f82a65"
 dependencies = [
  "heck",
  "proc-macro-error",

--- a/crates/esthri-cli/src/http_server.rs
+++ b/crates/esthri-cli/src/http_server.rs
@@ -215,6 +215,9 @@ fn with_bucket(bucket: String) -> impl Filter<Extract = (String,), Error = Infal
     warp::any().map(move || bucket.clone())
 }
 
+/// Lift allowed prefixes parameter into a warp handler/filter.  If allowed prefixes are empty then `None` is passed and
+/// all paths are allowed, also normalizes all prefixes so that they end in a slash.
+///
 fn with_allowed_prefixes(
     allowed_prefixes: &[String],
 ) -> impl Filter<Extract = (Option<Vec<String>>,), Error = Infallible> + Clone {
@@ -245,6 +248,9 @@ fn with_s3_client(
     warp::any().map(move || s3_client.clone())
 }
 
+/// * `allowed_prefixes` - specifies a list of prefixes which are allowed for access, all other prefixes will be
+/// rejected with HTTP status 404 (not found).
+///
 pub fn esthri_filter(
     s3_client: S3Client,
     bucket: &str,

--- a/crates/esthri-cli/src/http_server.rs
+++ b/crates/esthri-cli/src/http_server.rs
@@ -727,12 +727,7 @@ fn sanitize_filename(filename: String) -> String {
     )
 }
 
-fn should_reject(
-    path: &str,
-    allowed_prefixes: &[String],
-    params: &DownloadParams,
-) -> bool
-{
+fn should_reject(path: &str, allowed_prefixes: &[String], params: &DownloadParams) -> bool {
     if !allowed_prefixes.is_empty() {
         if allowed_prefixes.iter().any(|p| path.starts_with(p)) {
             false

--- a/crates/esthri-cli/src/http_server.rs
+++ b/crates/esthri-cli/src/http_server.rs
@@ -743,7 +743,7 @@ fn sanitize_filename(filename: String) -> String {
 
 fn should_reject(path: &str, allowed_prefixes: &[String], params: &DownloadParams) -> bool {
     // The with_allowed_prefixes filter should ensure that allowed_prefixes is not
-    //   not by the time we get here.
+    //   empty by the time we get here.
     assert!(!allowed_prefixes.is_empty());
     if allowed_prefixes.iter().any(|p| path.starts_with(p)) {
         false

--- a/crates/esthri-cli/tests/integration/http_server.rs
+++ b/crates/esthri-cli/tests/integration/http_server.rs
@@ -72,7 +72,10 @@ async fn test_allowed_prefixes() {
 
     assert!(res.is_ok());
 
-    let allowed_prefixes = ["allowed_prefix".to_owned(), "another_allowed_prefix/".to_owned()];
+    let allowed_prefixes = [
+        "allowed_prefix".to_owned(),
+        "another_allowed_prefix/".to_owned(),
+    ];
     let filter = esthri_filter((*s3client).clone(), bucket, &allowed_prefixes);
 
     let mut result = warp::test::request()

--- a/crates/esthri-cli/tests/integration/http_server.rs
+++ b/crates/esthri-cli/tests/integration/http_server.rs
@@ -28,7 +28,7 @@ async fn test_fetch_object() {
     .await;
     assert!(res.is_ok());
 
-    let filter = esthri_filter((*s3client).clone(), bucket);
+    let filter = esthri_filter((*s3client).clone(), bucket, &[]);
 
     let mut result = warp::test::request()
         .path("/test_file.txt")
@@ -61,7 +61,7 @@ async fn test_fetch_compressed_object_encoding() {
     upload_compressed_html_file().await;
     let s3client = esthri_test::get_s3client();
 
-    let filter = esthri_filter((*s3client).clone(), esthri_test::TEST_BUCKET);
+    let filter = esthri_filter((*s3client).clone(), esthri_test::TEST_BUCKET, &[]);
 
     let mut result = warp::test::request()
         .path("/index_compressed.html")
@@ -156,7 +156,7 @@ async fn fetch_archive_and_validate(
     upload_time: DateTime,
 ) {
     let s3client = esthri_test::get_s3client();
-    let filter = esthri_filter((*s3client).clone(), esthri_test::TEST_BUCKET);
+    let filter = esthri_filter((*s3client).clone(), esthri_test::TEST_BUCKET, &[]);
     let mut body = warp::test::request()
         .path(request_path)
         .filter(&filter)

--- a/crates/esthri/src/ops/download.rs
+++ b/crates/esthri/src/ops/download.rs
@@ -157,7 +157,7 @@ where
                 Result::Ok(())
             })
             .try_buffer_unordered(Config::global().concurrent_writer_tasks());
-        let _: () = stream.try_collect().await?;
+        stream.try_collect().await?;
     };
 
     // If we're trying to download into a directory, assemble the path for the user

--- a/crates/esthri/src/rusoto.rs
+++ b/crates/esthri/src/rusoto.rs
@@ -108,7 +108,7 @@ where
     }
 }
 
-#[derive(Copy, Clone, Debug, PartialEq, Deserialize)]
+#[derive(Copy, Clone, Debug, Eq, PartialEq, Deserialize)]
 #[serde(rename_all = "SCREAMING_SNAKE_CASE")]
 pub enum S3StorageClass {
     Standard,


### PR DESCRIPTION
Adds a list "directory" prefixes to allow, for example:

```
cargo run -- serve --bucket esthri-test --allowed-prefix test_upload/ --allowed-prefix test_list_directory/
```