### PR TITLE
fix CI breakage involving Git LFS

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -19,7 +19,7 @@ ARG CARGO_MAKE_URL=${CARGO_MAKE_URL_BASE}/${CARGO_MAKE_VER}/${CARGO_MAKE_FILE}
 
 RUN \
       apt-get update \
-   && apt-get install -y libssl-dev pkg-config curl openssh-client git-lfs binutils musl-dev musl-tools unzip \
+   && apt-get install -y libssl-dev pkg-config curl openssh-client git-lfs binutils musl-dev musl-tools unzip strace \
    && rm -rf /var/lib/apt/lists/* \
    && curl -sSL -o /tmp/sccache.tgz $SCCACHE_URL \
    && mkdir /tmp/sccache \

--- a/Dockerfile
+++ b/Dockerfile
@@ -19,7 +19,7 @@ ARG CARGO_MAKE_URL=${CARGO_MAKE_URL_BASE}/${CARGO_MAKE_VER}/${CARGO_MAKE_FILE}
 
 RUN \
       apt-get update \
-   && apt-get install -y libssl-dev pkg-config curl openssh-client git-lfs binutils musl-dev musl-tools unzip strace \
+   && apt-get install -y libssl-dev pkg-config curl openssh-client git-lfs binutils musl-dev musl-tools unzip \
    && rm -rf /var/lib/apt/lists/* \
    && curl -sSL -o /tmp/sccache.tgz $SCCACHE_URL \
    && mkdir /tmp/sccache \

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -82,7 +82,7 @@ pipeline {
               script {
                 sh("""/bin/bash -ex
                     |
-                    | git lfs install
+                    | strace -v -f -o strace.log git lfs install || cat strace.log
                     | git lfs pull
                     |
                     | cargo make test

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -79,10 +79,16 @@ pipeline {
           steps {
             gitPrep()
             lock(resource: "esthri-integration-tests") {
+              retry (10) {
+                sh("""/bin/bash -ex
+                    |
+                    | git lfs install || { sleep \$((1 + (RANDOM % 10))); false; }
+                    |
+                   """.stripMargin())
+              }
               script {
                 sh("""/bin/bash -ex
                     |
-                    | strace -v -f -o strace.log git lfs install || cat strace.log
                     | git lfs pull
                     |
                     | cargo make test
@@ -102,10 +108,16 @@ pipeline {
           steps {
             gitPrep()
             lock(resource: "esthri-integration-tests") {
+              retry (10) {
+                sh("""/bin/bash -ex
+                    |
+                    | git lfs install || { sleep \$((1 + (RANDOM % 10))); false; }
+                    |
+                   """.stripMargin())
+              }
               script {
                 sh("""/bin/bash -ex
                     |
-                    | strace -v -f -o strace.log git lfs install || cat strace.log
                     | git lfs pull
                     |
                     | cargo make test-min
@@ -125,10 +137,16 @@ pipeline {
           steps {
             gitPrep()
             lock(resource: "esthri-integration-tests") {
+              retry (10) {
+                sh("""/bin/bash -ex
+                    |
+                    | git lfs install || { sleep \$((1 + (RANDOM % 10))); false; }
+                    |
+                   """.stripMargin())
+              }
               script {
                 sh("""/bin/bash -ex
                     |
-                    | strace -v -f -o strace.log git lfs install || cat strace.log
                     | git lfs pull
                     |
                     | cargo make --profile dev+nativetls test
@@ -148,10 +166,16 @@ pipeline {
           steps {
             gitPrep()
             lock(resource: "esthri-integration-tests") {
+              retry (10) {
+                sh("""/bin/bash -ex
+                    |
+                    | git lfs install || { sleep \$((1 + (RANDOM % 10))); false; }
+                    |
+                   """.stripMargin())
+              }
               script {
                 sh("""/bin/bash -ex
                     |
-                    | strace -v -f -o strace.log git lfs install || cat strace.log
                     | git lfs pull
                     |
                     | cargo make --profile dev+nativetls test-min

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -82,7 +82,6 @@ pipeline {
               script {
                 sh("""/bin/bash -ex
                     |
-                    | strace -v -f -o strace.log git lfs install || cat strace.log
                     | git lfs pull
                     |
                     | cargo make test
@@ -105,7 +104,6 @@ pipeline {
               script {
                 sh("""/bin/bash -ex
                     |
-                    | strace -v -f -o strace.log git lfs install || cat strace.log
                     | git lfs pull
                     |
                     | cargo make test-min
@@ -128,7 +126,6 @@ pipeline {
               script {
                 sh("""/bin/bash -ex
                     |
-                    | strace -v -f -o strace.log git lfs install || cat strace.log
                     | git lfs pull
                     |
                     | cargo make --profile dev+nativetls test
@@ -151,7 +148,6 @@ pipeline {
               script {
                 sh("""/bin/bash -ex
                     |
-                    | strace -v -f -o strace.log git lfs install || cat strace.log
                     | git lfs pull
                     |
                     | cargo make --profile dev+nativetls test-min

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -79,16 +79,10 @@ pipeline {
           steps {
             gitPrep()
             lock(resource: "esthri-integration-tests") {
-              retry (10) {
-                sh("""/bin/bash -ex
-                    |
-                    | git lfs install || { sleep \$((1 + (RANDOM % 10))); false; }
-                    |
-                   """.stripMargin())
-              }
               script {
                 sh("""/bin/bash -ex
                     |
+                    | strace -v -f -o strace.log git lfs install || cat strace.log
                     | git lfs pull
                     |
                     | cargo make test
@@ -108,16 +102,10 @@ pipeline {
           steps {
             gitPrep()
             lock(resource: "esthri-integration-tests") {
-              retry (10) {
-                sh("""/bin/bash -ex
-                    |
-                    | git lfs install || { sleep \$((1 + (RANDOM % 10))); false; }
-                    |
-                   """.stripMargin())
-              }
               script {
                 sh("""/bin/bash -ex
                     |
+                    | strace -v -f -o strace.log git lfs install || cat strace.log
                     | git lfs pull
                     |
                     | cargo make test-min
@@ -137,16 +125,10 @@ pipeline {
           steps {
             gitPrep()
             lock(resource: "esthri-integration-tests") {
-              retry (10) {
-                sh("""/bin/bash -ex
-                    |
-                    | git lfs install || { sleep \$((1 + (RANDOM % 10))); false; }
-                    |
-                   """.stripMargin())
-              }
               script {
                 sh("""/bin/bash -ex
                     |
+                    | strace -v -f -o strace.log git lfs install || cat strace.log
                     | git lfs pull
                     |
                     | cargo make --profile dev+nativetls test
@@ -166,16 +148,10 @@ pipeline {
           steps {
             gitPrep()
             lock(resource: "esthri-integration-tests") {
-              retry (10) {
-                sh("""/bin/bash -ex
-                    |
-                    | git lfs install || { sleep \$((1 + (RANDOM % 10))); false; }
-                    |
-                   """.stripMargin())
-              }
               script {
                 sh("""/bin/bash -ex
                     |
+                    | strace -v -f -o strace.log git lfs install || cat strace.log
                     | git lfs pull
                     |
                     | cargo make --profile dev+nativetls test-min

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -105,7 +105,7 @@ pipeline {
               script {
                 sh("""/bin/bash -ex
                     |
-                    | git lfs install
+                    | strace -v -f -o strace.log git lfs install || cat strace.log
                     | git lfs pull
                     |
                     | cargo make test-min
@@ -128,7 +128,7 @@ pipeline {
               script {
                 sh("""/bin/bash -ex
                     |
-                    | git lfs install
+                    | strace -v -f -o strace.log git lfs install || cat strace.log
                     | git lfs pull
                     |
                     | cargo make --profile dev+nativetls test
@@ -151,7 +151,7 @@ pipeline {
               script {
                 sh("""/bin/bash -ex
                     |
-                    | git lfs install
+                    | strace -v -f -o strace.log git lfs install || cat strace.log
                     | git lfs pull
                     |
                     | cargo make --profile dev+nativetls test-min


### PR DESCRIPTION
Git LFS seemed to have changed lately and started failing with the following error in CI:

```
[2022-09-26T22:11:24.301Z] + /bin/bash -ex
[2022-09-26T22:11:24.301Z] + git lfs install
[2022-09-26T22:11:24.645Z] mkdir /dev/null: not a directory
[2022-09-26T22:11:24.645Z] To resolve this, either:
[2022-09-26T22:11:24.645Z]   1: run `git lfs update --manual` for instructions on how to merge hooks.
[2022-09-26T22:11:24.645Z]   2: run `git lfs update --force` to overwrite your hook.
script returned exit code 2
```

Removing the `git lfs install` call seems to fix this error.