### PR TITLE
Adding panic test for unset environment variable

### DIFF
--- a/crates/esthri-test/src/lib.rs
+++ b/crates/esthri-test/src/lib.rs
@@ -133,3 +133,22 @@ fn init_s3client() {
         Some(_) => {}
     }
 }
+
+#[cfg(test)]
+mod panic_test {
+    use super::*;
+
+    #[test]
+    #[should_panic]
+    fn test_dir_unset() {
+        let key = "WORKSPACE";
+        std::env::set_var(key, "somedir");
+        // no panic since env is set
+        test_data_dir();
+        assert_eq!(std::env::var(key), Ok("somedir".to_string()));
+
+        std::env::remove_var(key);
+        // panic due to unset env
+        test_data_dir();
+    }
+}


### PR DESCRIPTION
Purpose:
Part of onboarding exercise: https://swift-nav.atlassian.net/browse/DOL-160, please feel free to reject this PR

Technical Detail:
By setting and unsetting environment variable for the "WORKSPACE" key, it's able to test whether the unwrapping of test_data_dir() would panic when unit testing