### PR TITLE
Adding upload test for most of the testable storage classes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -546,6 +546,7 @@ dependencies = [
  "bytes",
  "chrono",
  "envy",
+ "esthri",
  "esthri-internals",
  "esthri-test",
  "fs_extra",
@@ -559,6 +560,8 @@ dependencies = [
  "parking_lot",
  "regex",
  "serde",
+ "strum",
+ "strum_macros",
  "tar",
  "tempdir",
  "tempfile",
@@ -1835,6 +1838,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustversion"
+version = "1.0.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "97477e48b4cf8603ad5f7aaf897467cf42ab4218a38ef76fb14c2d6773a6d6a8"
+
+[[package]]
 name = "ryu"
 version = "1.0.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2085,6 +2094,25 @@ name = "strsim"
 version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "73473c0e59e6d5812c5dfe2a064a6444949f089e20eec9a2e5506596494e4623"
+
+[[package]]
+name = "strum"
+version = "0.24.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "063e6045c0e62079840579a7e47a355ae92f60eb74daaf156fb1e84ba164e63f"
+
+[[package]]
+name = "strum_macros"
+version = "0.24.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e385be0d24f186b4ce2f9982191e7101bb737312ad61c1f2f984f34bcf85d59"
+dependencies = [
+ "heck",
+ "proc-macro2",
+ "quote",
+ "rustversion",
+ "syn",
+]
 
 [[package]]
 name = "subtle"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -546,7 +546,6 @@ dependencies = [
  "bytes",
  "chrono",
  "envy",
- "esthri",
  "esthri-internals",
  "esthri-test",
  "fs_extra",

--- a/crates/esthri/Cargo.toml
+++ b/crates/esthri/Cargo.toml
@@ -40,12 +40,15 @@ tokio-retry = "0.3"
 tokio-stream = "0.1"
 tokio-util = { version = "0.7", features = ["io"] }
 walkdir = "2"
+strum = "0.24.1"
+strum_macros = "0.24.3"
 
 [dependencies.esthri-internals]
 path = "../esthri-internals"
 
 [dev-dependencies]
 esthri-test = { path = "../esthri-test" }
+esthri = { path = "../esthri"}
 tar = "0.4"
 tempdir = "0.3"
 backtrace = "0.3"

--- a/crates/esthri/Cargo.toml
+++ b/crates/esthri/Cargo.toml
@@ -48,7 +48,6 @@ path = "../esthri-internals"
 
 [dev-dependencies]
 esthri-test = { path = "../esthri-test" }
-esthri = { path = "../esthri"}
 tar = "0.4"
 tempdir = "0.3"
 backtrace = "0.3"

--- a/crates/esthri/src/rusoto.rs
+++ b/crates/esthri/src/rusoto.rs
@@ -18,6 +18,7 @@ use std::str::FromStr;
 use bytes::Bytes;
 use chrono::{DateTime, Utc};
 use futures::Stream;
+use strum_macros::EnumIter;
 
 use crate::{retry::handle_dispatch_error, Error, Result};
 
@@ -102,7 +103,7 @@ where
     }
 }
 
-#[derive(Copy, Clone, Debug, Eq, PartialEq, Deserialize)]
+#[derive(Copy, Clone, Debug, Eq, PartialEq, Deserialize, EnumIter)]
 #[serde(rename_all = "SCREAMING_SNAKE_CASE")]
 pub enum S3StorageClass {
     Standard,

--- a/crates/esthri/tests/integration/upload_test.rs
+++ b/crates/esthri/tests/integration/upload_test.rs
@@ -6,6 +6,8 @@ use esthri::upload;
 use esthri::upload_from_reader;
 use esthri::HeadObjectInfo;
 
+use strum::IntoEnumIterator;
+
 #[test]
 fn test_upload() {
     let s3client = esthri_test::get_s3client();
@@ -117,47 +119,36 @@ fn test_upload_zero_size() {
 }
 
 #[test]
-fn test_upload_storage_class_rrs() {
+fn test_upload_staroge_class_all() {
     let s3client = esthri_test::get_s3client();
     let filename = "test5mb.bin";
     let filepath = esthri_test::test_data(filename);
     let s3_key = esthri_test::randomised_name(&format!("test_upload/{}", filename));
 
-    let res = esthri::blocking::upload_with_storage_class(
-        s3client.as_ref(),
-        esthri_test::TEST_BUCKET,
-        &s3_key,
-        &filepath,
-        S3StorageClass::RRS,
-    );
-    assert!(res.is_ok());
+    // 1. Glacier Class might take hours to populate metadata, skipping tests...
+    // Reference: https://aws.amazon.com/s3/faqs/
+    // 2. Uploading to S3 bucket in AWS region via OUTPOSTS is not supported, skipping test...
+    // Reference: https://docs.aws.amazon.com/AmazonS3/latest/userguide/storage-class-intro.html#s3-outposts
+    for class in S3StorageClass::iter().filter(|x| {
+        !x.eq(&S3StorageClass::GlacierDeepArchive)
+            && !x.eq(&S3StorageClass::GlacierFlexibleRetrieval)
+            && !x.eq(&S3StorageClass::GlacierInstantRetrieval)
+            && !x.eq(&S3StorageClass::Outposts)
+    }) {
+        let res = esthri::blocking::upload_with_storage_class(
+            s3client.as_ref(),
+            esthri_test::TEST_BUCKET,
+            &s3_key,
+            &filepath,
+            class,
+        );
+        assert!(res.is_ok());
 
-    let res = esthri::blocking::head_object(s3client.as_ref(), esthri_test::TEST_BUCKET, &s3_key);
-    let obj_info: Option<HeadObjectInfo> = res.unwrap();
-    assert!(obj_info.is_some());
-    let obj_info: HeadObjectInfo = obj_info.unwrap();
-    assert_eq!(obj_info.storage_class, S3StorageClass::RRS);
-}
-
-#[test]
-fn test_upload_storage_class_standard() {
-    let s3client = esthri_test::get_s3client();
-    let filename = "test5mb.bin";
-    let filepath = esthri_test::test_data(filename);
-    let s3_key = esthri_test::randomised_name(&format!("test_upload/{}", filename));
-
-    let res = esthri::blocking::upload_with_storage_class(
-        s3client.as_ref(),
-        esthri_test::TEST_BUCKET,
-        &s3_key,
-        &filepath,
-        S3StorageClass::Standard,
-    );
-    assert!(res.is_ok());
-
-    let res = esthri::blocking::head_object(s3client.as_ref(), esthri_test::TEST_BUCKET, &s3_key);
-    let obj_info: Option<HeadObjectInfo> = res.unwrap();
-    assert!(obj_info.is_some());
-    let obj_info: HeadObjectInfo = obj_info.unwrap();
-    assert_eq!(obj_info.storage_class, S3StorageClass::Standard);
+        let res =
+            esthri::blocking::head_object(s3client.as_ref(), esthri_test::TEST_BUCKET, &s3_key);
+        let obj_info: Option<HeadObjectInfo> = res.unwrap();
+        assert!(obj_info.is_some());
+        let obj_info: HeadObjectInfo = obj_info.unwrap();
+        assert_eq!(obj_info.storage_class, class);
+    }
 }

--- a/crates/esthri/tests/integration/upload_test.rs
+++ b/crates/esthri/tests/integration/upload_test.rs
@@ -119,7 +119,7 @@ fn test_upload_zero_size() {
 }
 
 #[test]
-fn test_upload_staroge_class_all() {
+fn test_upload_storage_class_all() {
     let s3client = esthri_test::get_s3client();
     let filename = "test5mb.bin";
     let filepath = esthri_test::test_data(filename);


### PR DESCRIPTION
Refactoring multiple identical S3StorageClass upload test functions to a single generalised function

Future work is to figure out better tests for classes that are not immediately testable via the upload_with_storage_class() function