### PR TITLE
use gtar for mac packaging

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -26,24 +26,29 @@ jobs:
             profile: release+static
             target: x86_64-unknown-linux-musl
             needs_musl: true
+            tar: tar
 
           - os: ubuntu-latest
             profile: release+static+aarch64
             target: aarch64-unknown-linux-musl
             needs_musl: true
+            tar: tar
 
           - os: macos-11
             profile: release+mac
             target: x86_64-apple-darwin
+            tar: gtar
 
           - os: macos-11
             profile: release+mac+aarch64
             target: aarch64-apple-darwin
+            tar: gtar
 
           - os: windows-2022
             profile: release+windows
             target: x86_64-pc-windows-msvc
             suffix: .exe
+            tar: tar
 
     steps:
       - name: Checkout source
@@ -83,7 +88,7 @@ jobs:
       - name: Package release
         shell: bash
         run: |
-          tar -C target/${{ matrix.target }}/release -czf esthri-${{ env.VERSION }}-${{ matrix.target }}.tar.gz esthri${{ matrix.suffix }}
+          ${{ matrix.tar }} -C target/${{ matrix.target }}/release -czf esthri-${{ env.VERSION }}-${{ matrix.target }}.tar.gz esthri${{ matrix.suffix }}
 
       - name: Upload Release
         uses: svenstaro/upload-release-action@v1-release


### PR DESCRIPTION
probably same issue like ICBINS, 
https://github.com/swift-nav/package-registry/pull/110

generating gnusparse file, not confirmed but pretty sure it is