### PR TITLE
add lifecycled prefix to temp s3 test files [DEVINFRA-630]

### DIFF
--- a/crates/esthri-test/src/lib.rs
+++ b/crates/esthri-test/src/lib.rs
@@ -55,6 +55,11 @@ pub fn randomised_name(name: &str) -> String {
     format!("{}-{}", Uuid::new_v4(), name)
 }
 
+// add prefix that s3 lifecycle policy would match to do deletion
+pub fn randomised_lifecycled_prefix(name: &str) -> String {
+    format!("test_runs_to_be_lifecycled/{}-{}", Uuid::new_v4(), name)
+}
+
 pub fn test_data_dir() -> PathBuf {
     let workspace = std::env::var("WORKSPACE").expect("WORKSPACE not set");
     PathBuf::from(workspace).join("crates/esthri-test/data")

--- a/crates/esthri/tests/integration/sync_test.rs
+++ b/crates/esthri/tests/integration/sync_test.rs
@@ -62,7 +62,7 @@ async fn test_sync_down_async() {
 fn test_sync_down_without_slash() {
     let s3client = esthri_test::get_s3client();
     let local_directory = esthri_test::test_data_dir();
-    let s3_key = esthri_test::randomised_name("test_folder");
+    let s3_key = esthri_test::randomised_lifecycled_prefix("test_folder");
     let filters: Option<Vec<GlobFilter>> = Some(vec![
         GlobFilter::Include(Pattern::new("*.txt").unwrap()),
         GlobFilter::Exclude(Pattern::new("*").unwrap()),
@@ -86,7 +86,7 @@ fn test_sync_down_without_slash() {
 fn test_sync_up_without_slash() {
     let s3client = esthri_test::get_s3client();
     let local_directory = esthri_test::test_data_dir();
-    let s3_key = esthri_test::randomised_name("test_folder");
+    let s3_key = esthri_test::randomised_lifecycled_prefix("test_folder");
     let filters: Option<Vec<GlobFilter>> = Some(vec![
         GlobFilter::Include(Pattern::new("*.txt").unwrap()),
         GlobFilter::Exclude(Pattern::new("*").unwrap()),
@@ -110,7 +110,7 @@ fn test_sync_up_without_slash() {
 fn test_sync_up() {
     let s3client = esthri_test::get_s3client();
     let local_directory = esthri_test::test_data_dir();
-    let s3_key = esthri_test::randomised_name("test_folder/");
+    let s3_key = esthri_test::randomised_lifecycled_prefix("test_folder/");
     let filters: Option<Vec<GlobFilter>> = Some(vec![
         GlobFilter::Include(Pattern::new("*.txt").unwrap()),
         GlobFilter::Exclude(Pattern::new("*").unwrap()),
@@ -134,7 +134,7 @@ fn test_sync_up() {
 async fn test_sync_up_async() {
     let s3client = esthri_test::get_s3client();
     let local_directory = esthri_test::test_data_dir();
-    let s3_key = esthri_test::randomised_name("test_folder/");
+    let s3_key = esthri_test::randomised_lifecycled_prefix("test_folder/");
     let filters: Option<Vec<GlobFilter>> = Some(vec![
         GlobFilter::Include(Pattern::new("*.txt").unwrap()),
         GlobFilter::Exclude(Pattern::new("*").unwrap()),
@@ -159,7 +159,7 @@ async fn test_sync_up_async() {
 fn test_sync_up_default() {
     let s3client = esthri_test::get_s3client();
     let local_directory = esthri_test::test_data("sync_up");
-    let s3_key = esthri_test::randomised_name("test_sync_up_default/");
+    let s3_key = esthri_test::randomised_lifecycled_prefix("test_sync_up_default/");
 
     let source = S3PathParam::new_local(&local_directory);
     let destination = S3PathParam::new_bucket(esthri_test::TEST_BUCKET, &s3_key);
@@ -196,7 +196,7 @@ fn test_sync_up_default() {
 fn test_sync_up_delete() {
     let s3client = esthri_test::get_s3client();
     let local_directory = esthri_test::copy_test_data("sync_up");
-    let s3_key_prefix = esthri_test::randomised_name("test_sync_up_delete/");
+    let s3_key_prefix = esthri_test::randomised_lifecycled_prefix("test_sync_up_delete/");
 
     let source = S3PathParam::new_local(&local_directory);
     let destination = S3PathParam::new_bucket(esthri_test::TEST_BUCKET, &s3_key_prefix);
@@ -276,7 +276,7 @@ fn test_sync_down_delete() {
     // Get path to some directory and populate it.
     let local_directory = esthri_test::copy_test_data("sync_up");
     // Create a key that correspods to non-existant data in an S3 bucket
-    let s3_key_prefix = esthri_test::randomised_name("test_sync_down_delete/");
+    let s3_key_prefix = esthri_test::randomised_lifecycled_prefix("test_sync_down_delete/");
 
     let src = S3PathParam::new_bucket(esthri_test::TEST_BUCKET, &s3_key_prefix);
     let dst = S3PathParam::new_local(&local_directory);
@@ -313,8 +313,10 @@ fn test_sync_down_delete() {
 fn test_sync_across_delete() {
     let s3client = esthri_test::get_s3client();
     // Indicate two empty S3 keys to perform opperations on.
-    let s3_key_src_prefix = esthri_test::randomised_name("test_sync_across_delete_src/");
-    let s3_key_dst_prefix = esthri_test::randomised_name("test_sync_across_delete_dst/");
+    let s3_key_src_prefix =
+        esthri_test::randomised_lifecycled_prefix("test_sync_across_delete_src/");
+    let s3_key_dst_prefix =
+        esthri_test::randomised_lifecycled_prefix("test_sync_across_delete_dst/");
 
     // Create a dummy file. Deletion of this file will be indicative of test success
     let temp_directory = tempdir().expect("Unabel to create temp directory");
@@ -461,7 +463,7 @@ fn test_sync_down_filter() {
 async fn test_sync_across() {
     let s3client = esthri_test::get_s3client();
     let source_prefix = "test_sync_folder1/";
-    let dest_prefix = esthri_test::randomised_name("test_sync_folder2/");
+    let dest_prefix = esthri_test::randomised_lifecycled_prefix("test_sync_folder2/");
 
     let filters: Option<Vec<GlobFilter>> =
         Some(vec![GlobFilter::Include(Pattern::new("*.txt").unwrap())]);
@@ -503,7 +505,7 @@ fn sync_test_files_up_compressed(s3client: &S3Client, s3_key: &str) -> String {
 #[test]
 fn test_sync_up_compressed() {
     let s3client = esthri_test::get_s3client();
-    let key = esthri_test::randomised_name("test_sync_up_compressed/");
+    let key = esthri_test::randomised_lifecycled_prefix("test_sync_up_compressed/");
     let s3_key = sync_test_files_up_compressed(s3client.as_ref(), &key);
 
     let key_hash_pairs = [
@@ -529,7 +531,7 @@ fn test_sync_up_compressed() {
 #[test]
 fn test_sync_down_compressed() {
     let s3client = esthri_test::get_s3client();
-    let s3_key = esthri_test::randomised_name("test_sync_down_compressed_v7/");
+    let s3_key = esthri_test::randomised_lifecycled_prefix("test_sync_down_compressed_v7/");
 
     sync_test_files_up_compressed(s3client.as_ref(), &s3_key);
 
@@ -567,7 +569,7 @@ fn test_sync_down_compressed() {
 #[test]
 fn test_sync_down_compressed_mixed() {
     let s3client = esthri_test::get_s3client();
-    let s3_key = esthri_test::randomised_name("test_sync_down_compressed_mixed_v7/");
+    let s3_key = esthri_test::randomised_lifecycled_prefix("test_sync_down_compressed_mixed_v7/");
 
     blocking::upload(
         s3client.as_ref(),

--- a/crates/esthri/tests/integration/upload_test.rs
+++ b/crates/esthri/tests/integration/upload_test.rs
@@ -13,7 +13,7 @@ fn test_upload() {
     let s3client = esthri_test::get_s3client();
     let filename = "test5mb.bin";
     let filepath = esthri_test::test_data(filename);
-    let s3_key = esthri_test::randomised_name(&format!("test_upload/{}", filename));
+    let s3_key = esthri_test::randomised_lifecycled_prefix(&format!("test_upload/{}", filename));
 
     let res = esthri::blocking::upload(
         s3client.as_ref(),
@@ -39,7 +39,7 @@ fn test_upload_compressed() {
     let s3client = esthri_test::get_s3client();
     let filename = "27-185232-msg.csv";
     let filepath = esthri_test::test_data(filename);
-    let s3_key = esthri_test::randomised_name(&format!("test_upload/{}", filename));
+    let s3_key = esthri_test::randomised_lifecycled_prefix(&format!("test_upload/{}", filename));
 
     let res = esthri::blocking::upload_compressed(
         s3client.as_ref(),
@@ -70,7 +70,7 @@ async fn test_upload_async() {
     let s3client = esthri_test::get_s3client();
     let filename = "test5mb.bin";
     let filepath = esthri_test::test_data(filename);
-    let s3_key = esthri_test::randomised_name(&format!("test_upload/{}", filename));
+    let s3_key = esthri_test::randomised_lifecycled_prefix(&format!("test_upload/{}", filename));
 
     let res = upload(
         s3client.as_ref(),
@@ -86,7 +86,8 @@ async fn test_upload_async() {
 async fn test_upload_reader() {
     let s3client = esthri_test::get_s3client();
     let filename = "test_reader_upload.bin";
-    let filepath = esthri_test::randomised_name(&format!("test_upload_reader/{}", filename));
+    let filepath =
+        esthri_test::randomised_lifecycled_prefix(&format!("test_upload_reader/{}", filename));
     let contents = "file contents";
     let reader = Cursor::new(contents);
 
@@ -107,7 +108,8 @@ fn test_upload_zero_size() {
     let s3client = esthri_test::get_s3client();
     let filename = "test0b.bin";
     let filepath = esthri_test::test_data(filename);
-    let s3_key = esthri_test::randomised_name(&format!("test_upload_zero_size/{}", filename));
+    let s3_key =
+        esthri_test::randomised_lifecycled_prefix(&format!("test_upload_zero_size/{}", filename));
 
     let res = blocking::upload(
         s3client.as_ref(),
@@ -123,7 +125,7 @@ fn test_upload_storage_class_all() {
     let s3client = esthri_test::get_s3client();
     let filename = "test5mb.bin";
     let filepath = esthri_test::test_data(filename);
-    let s3_key = esthri_test::randomised_name(&format!("test_upload/{}", filename));
+    let s3_key = esthri_test::randomised_lifecycled_prefix(&format!("test_upload/{}", filename));
 
     // 1. Glacier Class might take hours to populate metadata, skipping tests...
     // Reference: https://aws.amazon.com/s3/faqs/


### PR DESCRIPTION
add prefix to integration temp test files so this s3 [lifecycle policy](https://s3.console.aws.amazon.com/s3/management/esthri-test/lifecycle/view?region=us-west-2&id=delete_test_runs_after_7_days) would match to do deletion

this lifecycle policy doesn't retrospectively apply to the existing randomised temp test files, might need to do an once-off cleanup