### PR TITLE
add Send/Sync tests

### DIFF
--- a/crates/esthri/tests/integration/main.rs
+++ b/crates/esthri/tests/integration/main.rs
@@ -3,6 +3,7 @@
 mod delete_test;
 mod download_test;
 mod list_object_test;
+mod send_sync;
 mod sync_test;
 mod upload_test;
 

--- a/crates/esthri/tests/integration/send_sync.rs
+++ b/crates/esthri/tests/integration/send_sync.rs
@@ -1,0 +1,117 @@
+use std::{cell::Cell, future, path::Path, pin::Pin, rc::Rc};
+
+use tokio::io;
+
+use esthri::opts;
+
+// From https://github.com/tokio-rs/tokio/blob/master/tokio/tests/async_send_sync.rs
+
+// The names of these structs behaves better when sorted.
+// Send: Yes, Sync: Yes
+#[derive(Clone)]
+struct YY {}
+
+// Send: Yes, Sync: No
+#[derive(Clone)]
+struct YN {
+    _value: Cell<u8>,
+}
+
+// Send: No, Sync: No
+#[derive(Clone)]
+struct NN {
+    _value: Rc<u8>,
+}
+
+#[allow(dead_code)]
+type BoxFutureSync<T> = Pin<Box<dyn future::Future<Output = T> + Send + Sync>>;
+#[allow(dead_code)]
+type BoxFutureSend<T> = Pin<Box<dyn future::Future<Output = T> + Send>>;
+#[allow(dead_code)]
+type BoxFuture<T> = Pin<Box<dyn future::Future<Output = T>>>;
+
+#[allow(dead_code)]
+type BoxAsyncRead = Pin<Box<dyn io::AsyncBufRead + Send + Sync>>;
+#[allow(dead_code)]
+type BoxAsyncSeek = Pin<Box<dyn io::AsyncSeek + Send + Sync>>;
+#[allow(dead_code)]
+type BoxAsyncWrite = Pin<Box<dyn io::AsyncWrite + Send + Sync>>;
+
+#[allow(dead_code)]
+fn require_send<T: Send>(_t: &T) {}
+#[allow(dead_code)]
+fn require_sync<T: Sync>(_t: &T) {}
+#[allow(dead_code)]
+fn require_unpin<T: Unpin>(_t: &T) {}
+
+#[allow(dead_code)]
+struct Invalid;
+
+trait AmbiguousIfSend<A> {
+    fn some_item(&self) {}
+}
+impl<T: ?Sized> AmbiguousIfSend<()> for T {}
+impl<T: ?Sized + Send> AmbiguousIfSend<Invalid> for T {}
+
+trait AmbiguousIfSync<A> {
+    fn some_item(&self) {}
+}
+impl<T: ?Sized> AmbiguousIfSync<()> for T {}
+impl<T: ?Sized + Sync> AmbiguousIfSync<Invalid> for T {}
+
+trait AmbiguousIfUnpin<A> {
+    fn some_item(&self) {}
+}
+impl<T: ?Sized> AmbiguousIfUnpin<()> for T {}
+impl<T: ?Sized + Unpin> AmbiguousIfUnpin<Invalid> for T {}
+
+macro_rules! into_todo {
+    ($typ:ty) => {{
+        let x: $typ = todo!();
+        x
+    }};
+}
+
+macro_rules! async_assert_fn_send {
+    (Send & $(!)?Sync & $(!)?Unpin, $value:expr) => {
+        require_send(&$value);
+    };
+    (!Send & $(!)?Sync & $(!)?Unpin, $value:expr) => {
+        AmbiguousIfSend::some_item(&$value);
+    };
+}
+
+macro_rules! async_assert_fn_sync {
+    ($(!)?Send & Sync & $(!)?Unpin, $value:expr) => {
+        require_sync(&$value);
+    };
+    ($(!)?Send & !Sync & $(!)?Unpin, $value:expr) => {
+        AmbiguousIfSync::some_item(&$value);
+    };
+}
+
+macro_rules! async_assert_fn_unpin {
+    ($(!)?Send & $(!)?Sync & Unpin, $value:expr) => {
+        require_unpin(&$value);
+    };
+    ($(!)?Send & $(!)?Sync & !Unpin, $value:expr) => {
+        AmbiguousIfUnpin::some_item(&$value);
+    };
+}
+
+macro_rules! async_assert_fn {
+    ($($f:ident $(< $($generic:ty),* > )? )::+($($arg:ty),*): $($tok:tt)*) => {
+        #[allow(unreachable_code)]
+        #[allow(unused_variables)]
+        const _: fn() = || {
+            let f = $($f $(::<$($generic),*>)? )::+( $( into_todo!($arg) ),* );
+            async_assert_fn_send!($($tok)*, f);
+            async_assert_fn_sync!($($tok)*, f);
+            async_assert_fn_unpin!($($tok)*, f);
+        };
+    };
+}
+
+async_assert_fn!(
+    esthri::upload(_, &str, &str, &Path, opts::EsthriPutOptParams): Send & !Sync & !Unpin
+);


### PR DESCRIPTION
Figured out a way to show/test an issue I've talked about before

```
error: future cannot be sent between threads safely
   --> crates/esthri/tests/integration/send_sync.rs:77:22
    |
77  |           require_send(&$value);
    |                        ^^^^^^^ future is not `Send`
...
115 | / async_assert_fn!(
116 | |     esthri::upload(_, &str, &str, &Path, opts::EsthriPutOptParams): Send & !Sync & !Unpin
117 | | );
    | |_- in this macro invocation
    |
    = help: the trait `Sync` is not implemented for `(dyn Stream<Item = Result<esthri_internals::hyper::body::Bytes, std::io::Error>> + std::marker::Send + 'static)`
note: required by a bound in `require_send`
   --> crates/esthri/tests/integration/send_sync.rs:41:20
    |
41  | fn require_send<T: Send>(_t: &T) {}
    |                    ^^^^ required by this bound in `require_send`
    = note: this error originates in the macro `async_assert_fn_send` which comes from the expansion of the macro `async_assert_fn` (in Nightly builds, run with -Z macro-backtrace for more info)

warning: `esthri` (test "integration") generated 2 warnings
```

namely that the futures returned by some of the functions aren't Send which can make them more challenging to work with