### PR TITLE
add granular credential provider options [DEVINFRA-1038]

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -47,6 +47,7 @@ jobs:
       - name: Install musl tools
         if: matrix.needs_musl
         run: >-
+          sudo apt-get update
           sudo apt-get install
           clang
           llvm

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -47,7 +47,7 @@ jobs:
       - name: Install musl tools
         if: matrix.needs_musl
         run: >-
-          sudo apt-get update
+          sudo apt-get update && 
           sudo apt-get install
           clang
           llvm

--- a/README.md
+++ b/README.md
@@ -80,6 +80,7 @@ CREDENTIAL_PROVIDER=profile esthri s3 sync s3://esthri-test/myfiles/ mynewdirect
 `ESTHRI_CREDENTIAL_PROVIDER=profile` ---> fetched from default credential file
 `ESTHRI_CREDENTIAL_PROVIDER=container` ---> fetched from task's IAM role in ECS
 `ESTHRI_CREDENTIAL_PROVIDER=instance_metadata` ---> fetched from instance metadata service
+`ESTHRI_CREDENTIAL_PROVIDER=esthri` ---> explicitly using default credential provider
 
 If not set the program will fall back to default credential provider in which the
 above providers are iterated through in the above order until the first working value is found

--- a/README.md
+++ b/README.md
@@ -80,7 +80,7 @@ CREDENTIAL_PROVIDER=profile esthri s3 sync s3://esthri-test/myfiles/ mynewdirect
 `ESTHRI_CREDENTIAL_PROVIDER=profile` ---> fetched from default credential file
 `ESTHRI_CREDENTIAL_PROVIDER=container` ---> fetched from task's IAM role in ECS
 `ESTHRI_CREDENTIAL_PROVIDER=instance_metadata` ---> fetched from instance metadata service
-`ESTHRI_CREDENTIAL_PROVIDER=esthri` ---> explicitly using default credential provider
+`ESTHRI_CREDENTIAL_PROVIDER=` ---> explicitly using default credential provider if empty
 
 If not set the program will fall back to default credential provider in which the
 above providers are iterated through in the above order until the first working value is found

--- a/README.md
+++ b/README.md
@@ -67,6 +67,23 @@ esthri version number in the metadata of files it has compressed. For this
 reason, the decompression will only work for files that esthri has compressed
 itself.
 
+## AWS credential provider selection
+
+It is highly recommended to set a specific credential provider which gives you
+better security and granular level of control. e.g:
+
+```
+CREDENTIAL_PROVIDER=profile esthri s3 sync s3://esthri-test/myfiles/ mynewdirectory/
+```
+
+`ESTHRI_CREDENTIAL_PROVIDER=env` ---> fetched from environment variables
+`ESTHRI_CREDENTIAL_PROVIDER=profile` ---> fetched from default credential file
+`ESTHRI_CREDENTIAL_PROVIDER=container` ---> fetched from task's IAM role in ECS
+`ESTHRI_CREDENTIAL_PROVIDER=instance_metadata` ---> fetched from instance metadata service
+
+If not set the program will fall back to default credential provider in which the
+above providers are iterated through in the above order until the first working value is found
+
 ## Releasing
 
 [cargo-release](https://github.com/crate-ci/cargo-release) is used to automate

--- a/crates/esthri-cli/src/cli_utils.rs
+++ b/crates/esthri-cli/src/cli_utils.rs
@@ -180,7 +180,7 @@ pub fn setup_s3client_with_cred_provider() -> Result<S3Client> {
                     Region::default(),
                 ))
             }
-            "esthri" => {
+            "" => {
                 let credentials_provider = DefaultCredentialsProvider::new().unwrap();
                 Ok(S3Client::new_with(
                     http_client,
@@ -189,7 +189,7 @@ pub fn setup_s3client_with_cred_provider() -> Result<S3Client> {
                 ))
             }
             _ => {
-                bail!("unset or unsupported credential provider environment variable, program aborting");
+                bail!("unsupported credential provider environment variable, program aborting");
             }
         },
         Err(_) => {

--- a/crates/esthri-cli/src/cli_utils.rs
+++ b/crates/esthri-cli/src/cli_utils.rs
@@ -151,27 +151,27 @@ pub fn setup_s3client_with_cred_provider() -> S3Client {
             "env" => {
                 let credentials_provider = EnvironmentProvider::default();
                 S3Client::new_with(http_client, credentials_provider, Region::default())
-            },
+            }
             "profile" => {
                 let credentials_provider = ProfileProvider::new().unwrap();
                 S3Client::new_with(http_client, credentials_provider, Region::default())
-            },
+            }
             "container" => {
                 let credentials_provider = ContainerProvider::new();
                 S3Client::new_with(http_client, credentials_provider, Region::default())
-            },
+            }
             "instance_metadata" => {
                 let credentials_provider = InstanceMetadataProvider::new();
                 S3Client::new_with(http_client, credentials_provider, Region::default())
-            },
+            }
             _ => {
                 println!("unset or unsupported credential provider environment variable, program aborting");
                 std::process::exit(1)
-            },
+            }
         },
         Err(_) => {
             let credentials_provider = DefaultCredentialsProvider::new().unwrap();
             S3Client::new_with(http_client, credentials_provider, Region::default())
-        },
+        }
     }
 }

--- a/crates/esthri-cli/src/main.rs
+++ b/crates/esthri-cli/src/main.rs
@@ -17,12 +17,9 @@ mod http_server;
 mod cli_opts;
 mod cli_utils;
 
-use std::time::Duration;
-
 use anyhow::Result;
 use clap::{CommandFactory, Parser, Subcommand};
 use glob::Pattern;
-use hyper::Client;
 use log::*;
 use tokio::runtime::Builder;
 
@@ -265,14 +262,7 @@ async fn async_main() -> Result<()> {
 
     info!("Starting, using region: {:?}...", region);
 
-    let mut hyper_builder = Client::builder();
-    hyper_builder.pool_idle_timeout(Duration::from_secs(20));
-
-    let https_connector = esthri::new_https_connector();
-    let http_client = HttpClient::from_builder(hyper_builder, https_connector);
-
-    let credentials_provider = DefaultCredentialsProvider::new().unwrap();
-    let s3 = S3Client::new_with(http_client, credentials_provider, Region::default());
+    let s3 = setup_s3client_with_cred_provider();
 
     if aws_compat_mode {
         let args = AwsCompatCli::try_parse().map_err(|e| {

--- a/crates/esthri-cli/src/main.rs
+++ b/crates/esthri-cli/src/main.rs
@@ -262,7 +262,7 @@ async fn async_main() -> Result<()> {
 
     info!("Starting, using region: {:?}...", region);
 
-    let s3 = setup_s3client_with_cred_provider();
+    let s3 = setup_s3client_with_cred_provider()?;
 
     if aws_compat_mode {
         let args = AwsCompatCli::try_parse().map_err(|e| {

--- a/crates/esthri-cli/tests/integration/cli_test.rs
+++ b/crates/esthri-cli/tests/integration/cli_test.rs
@@ -281,7 +281,9 @@ fn test_sync_transparent_compression() {
 }
 
 #[test]
-#[should_panic(expected = "unset or unsupported credential provider environment variable, program aborting")]
+#[should_panic(
+    expected = "unset or unsupported credential provider environment variable, program aborting"
+)]
 fn unset_credential() {
     let s3_path = "s3://esthri-test/test-syncup-compress/";
 

--- a/crates/esthri-cli/tests/integration/cli_test.rs
+++ b/crates/esthri-cli/tests/integration/cli_test.rs
@@ -281,15 +281,13 @@ fn test_sync_transparent_compression() {
 }
 
 #[test]
-#[should_panic(
-    expected = "unset or unsupported credential provider environment variable, program aborting"
-)]
+#[should_panic(expected = "unsupported credential provider environment variable, program aborting")]
 fn unset_credential() {
     let s3_path = "s3://esthri-test/test-syncup-compress/";
 
     let mut cmd = Command::cargo_bin("esthri").unwrap();
     let assert = cmd
-        .env("ESTHRI_CREDENTIAL_PROVIDER", "")
+        .env("ESTHRI_CREDENTIAL_PROVIDER", "unknown")
         .arg("s3")
         .arg("sync")
         .arg("--transparent-compression")

--- a/crates/esthri-cli/tests/integration/cli_test.rs
+++ b/crates/esthri-cli/tests/integration/cli_test.rs
@@ -279,3 +279,20 @@ fn test_sync_transparent_compression() {
 
     validate_key_hash_pairs(local_path, &key_hash_pairs);
 }
+
+#[test]
+#[should_panic(expected = "unset or unsupported credential provider environment variable, program aborting")]
+fn unset_credential() {
+    let s3_path = "s3://esthri-test/test-syncup-compress/";
+
+    let mut cmd = Command::cargo_bin("esthri").unwrap();
+    let assert = cmd
+        .env("ESTHRI_CREDENTIAL_PROVIDER", "")
+        .arg("s3")
+        .arg("sync")
+        .arg("--transparent-compression")
+        .arg(esthri_test::test_data("sync_up/"))
+        .arg(s3_path)
+        .assert();
+    assert.success();
+}


### PR DESCRIPTION
For better security and granular level of control, Esthri should be recommended to use a specific credential provider via an environment variable, only to fall back to the default credential provider if variable not set should the users choose to