### PR TITLE
fix lints in esthri test code

### DIFF
--- a/crates/esthri-cli/tests/integration/http_server.rs
+++ b/crates/esthri-cli/tests/integration/http_server.rs
@@ -203,7 +203,7 @@ fn upload_test_data() -> anyhow::Result<()> {
         blocking::upload(
             s3client.as_ref(),
             esthri_test::TEST_BUCKET,
-            &s3_key,
+            s3_key,
             filepath.to_str().unwrap(),
             opts,
         )?;
@@ -236,7 +236,7 @@ fn extract_zip_archive(mut archive: zip::ZipArchive<Cursor<&bytes::Bytes>>) -> a
         };
         if let Some(p) = outpath.parent() {
             if !p.exists() {
-                fs::create_dir_all(&p)?;
+                fs::create_dir_all(p)?;
             }
         }
         let mut outfile = fs::File::create(&outpath)?;
@@ -264,7 +264,7 @@ fn validate_fetch_archive(
     for key_hash_pair in key_hash_pairs {
         let filename = Path::new(key_hash_pair.0);
         let filepath = Path::new(local_dir).join(filename);
-        let file_last_mod = std::fs::metadata(&filepath)
+        let file_last_mod = std::fs::metadata(filepath)
             .expect("stat'ing test file path")
             .modified()
             .expect("last modified timestamp");
@@ -395,8 +395,8 @@ fn test_fetch_archive_with_compressed_files() {
     let res = blocking::upload(
         s3client.as_ref(),
         esthri_test::TEST_BUCKET,
-        &s3_key,
-        &filename,
+        s3_key,
+        filename,
         opts_compressed,
     );
     assert!(res.is_ok());
@@ -407,8 +407,8 @@ fn test_fetch_archive_with_compressed_files() {
     let res = blocking::upload(
         s3client.as_ref(),
         esthri_test::TEST_BUCKET,
-        &s3_key,
-        &filename,
+        s3_key,
+        filename,
         opts,
     );
     assert!(res.is_ok());

--- a/crates/esthri/tests/integration/delete_test.rs
+++ b/crates/esthri/tests/integration/delete_test.rs
@@ -9,7 +9,7 @@ use esthri_internals::rusoto::S3Client;
 async fn test_delete() {
     let (s3client, s3_key, bucket, s3_key2) = upload_test_data().await;
     let s3client = s3client.as_ref();
-    let result = esthri::delete(s3client, &bucket, &vec![&s3_key, &s3_key2]).await;
+    let result = esthri::delete(s3client, &bucket, &[&s3_key, &s3_key2]).await;
     assert!(result.is_ok());
     let result = esthri::head_object(s3client, &bucket, &s3_key).await;
     assert!(result.unwrap().is_none());
@@ -31,9 +31,9 @@ async fn test_delete_streaming() {
 fn test_delete_blocking() {
     let (s3client, s3_key, bucket, s3_key2) = blocking::upload_test_data();
     let s3client = s3client.as_ref();
-    let result = esthri::blocking::delete(s3client, &bucket, &vec![&s3_key]);
+    let result = esthri::blocking::delete(s3client, &bucket, &[&s3_key]);
     assert!(result.is_ok());
-    let result = esthri::blocking::delete(s3client, &bucket, &vec![&s3_key2]);
+    let result = esthri::blocking::delete(s3client, &bucket, &[&s3_key2]);
     assert!(result.is_ok());
     let result = esthri::blocking::head_object(s3client, &bucket, &s3_key);
     assert!(result.unwrap().is_none());

--- a/crates/esthri/tests/integration/download_test.rs
+++ b/crates/esthri/tests/integration/download_test.rs
@@ -14,8 +14,8 @@ fn test_download() {
     let res = blocking::download(
         s3client.as_ref(),
         esthri_test::TEST_BUCKET,
-        &s3_key,
-        &filepath,
+        s3_key,
+        filepath,
         opts,
     );
     assert!(res.is_ok());
@@ -35,7 +35,7 @@ fn test_download_to_nonexistent_path() {
     let res = blocking::download(
         s3client.as_ref(),
         esthri_test::TEST_BUCKET,
-        &s3_key,
+        s3_key,
         &filepath,
         opts,
     );
@@ -55,8 +55,8 @@ fn test_download_to_current_directory() {
     let res = blocking::download(
         s3client.as_ref(),
         esthri_test::TEST_BUCKET,
-        &s3_key,
-        &filepath,
+        s3_key,
+        filepath,
         opts,
     );
     assert!(res.is_ok());
@@ -122,8 +122,8 @@ fn test_download_decompressed() {
     let res = blocking::download(
         s3client.as_ref(),
         esthri_test::TEST_BUCKET,
-        &s3_key,
-        &filename,
+        s3_key,
+        filename,
         opts,
     );
     assert!(res.is_ok());
@@ -148,7 +148,7 @@ fn test_download_decompressed_to_directory() {
     let res = blocking::download(
         s3client.as_ref(),
         esthri_test::TEST_BUCKET,
-        &s3_key,
+        s3_key,
         ".",
         opts,
     );
@@ -174,7 +174,7 @@ fn test_download_transparent_with_non_compressed() {
     let res = blocking::download(
         s3client.as_ref(),
         esthri_test::TEST_BUCKET,
-        &s3_key,
+        s3_key,
         local_dir_path,
         opts,
     );

--- a/crates/esthri/tests/integration/list_object_test.rs
+++ b/crates/esthri/tests/integration/list_object_test.rs
@@ -20,7 +20,7 @@ fn test_head_object() {
         s3client.as_ref(),
         esthri_test::TEST_BUCKET,
         &s3_key,
-        &filepath,
+        filepath,
         opts,
     );
     assert!(res.is_ok());
@@ -75,8 +75,8 @@ fn test_list_objects() {
     let res = blocking::upload(
         s3client.as_ref(),
         esthri_test::TEST_BUCKET,
-        &not_empty_s3_key,
-        &filepath,
+        not_empty_s3_key,
+        filepath,
         opts,
     );
     assert!(res.is_ok());
@@ -84,7 +84,7 @@ fn test_list_objects() {
     let res = blocking::list_objects(
         s3client.as_ref(),
         esthri_test::TEST_BUCKET,
-        &not_empty_folder,
+        not_empty_folder,
     );
     let bucket_contents = res.unwrap();
     assert_eq!(1, bucket_contents.len());
@@ -93,7 +93,7 @@ fn test_list_objects() {
         bucket_contents[0]
     );
 
-    let res = blocking::list_objects(s3client.as_ref(), esthri_test::TEST_BUCKET, &empty_folder);
+    let res = blocking::list_objects(s3client.as_ref(), esthri_test::TEST_BUCKET, empty_folder);
     let bucket_contents = res.unwrap();
     assert!(bucket_contents.is_empty())
 }

--- a/crates/esthri/tests/integration/main.rs
+++ b/crates/esthri/tests/integration/main.rs
@@ -11,7 +11,7 @@ mod upload_test;
 async fn test_get_bucket_location() {
     let s3client = esthri_test::get_s3client();
     let bucket = esthri_test::TEST_BUCKET;
-    let location = esthri::rusoto::get_bucket_location(s3client.as_ref(), &bucket)
+    let location = esthri::rusoto::get_bucket_location(s3client.as_ref(), bucket)
         .await
         .expect("get_bucket_location failed");
     assert_eq!(location, "us-west-2");

--- a/crates/esthri/tests/integration/presign.rs
+++ b/crates/esthri/tests/integration/presign.rs
@@ -18,7 +18,7 @@ async fn test_presign_get() {
 
     let creds = creds().await;
 
-    let presigned_url = presign_get(&creds, &region, &bucket, &s3_key, None);
+    let presigned_url = presign_get(&creds, &region, bucket, &s3_key, None);
 
     let tmpdir = TempDir::new("esthri_tmp").expect("creating temporary directory");
     let download_file_path = tmpdir.path().join(filename);
@@ -48,7 +48,7 @@ async fn test_presign_put() {
 
     let opts = EsthriPutOptParamsBuilder::default().build().unwrap();
 
-    let presigned_url = presign_put(&creds, &region, &bucket, &s3_key, None, opts.clone());
+    let presigned_url = presign_put(&creds, &region, bucket, &s3_key, None, opts);
     upload_file_presigned(&Client::new(), &presigned_url, &filepath, opts)
         .await
         .unwrap();
@@ -79,7 +79,7 @@ async fn test_presign_delete() {
     )
     .await
     .unwrap();
-    assert!(esthri::head_object(s3, bucket.to_owned(), s3_key.clone())
+    assert!(esthri::head_object(s3, bucket.to_owned(), s3_key)
         .await
         .unwrap()
         .is_some());
@@ -87,7 +87,7 @@ async fn test_presign_delete() {
     let region = Region::default();
     let creds = creds().await;
 
-    let presigned_url = presign_delete(&creds, &region, &bucket, &s3_key, None);
+    let presigned_url = presign_delete(&creds, &region, bucket, s3_key, None);
     delete_file_presigned(&Client::new(), &presigned_url)
         .await
         .unwrap();

--- a/crates/esthri/tests/integration/sync_test.rs
+++ b/crates/esthri/tests/integration/sync_test.rs
@@ -23,7 +23,7 @@ fn test_sync_down() {
     ]);
 
     let source = S3PathParam::new_bucket(esthri_test::TEST_BUCKET, s3_key);
-    let destination = S3PathParam::new_local(&local_directory);
+    let destination = S3PathParam::new_local(local_directory);
     let opts = SharedSyncOptParamsBuilder::default().build().unwrap();
 
     let res = esthri::blocking::sync(
@@ -72,7 +72,7 @@ fn test_sync_down_without_slash() {
     ]);
 
     let source = S3PathParam::new_bucket(esthri_test::TEST_BUCKET, s3_key);
-    let destination = S3PathParam::new_local(&local_directory);
+    let destination = S3PathParam::new_local(local_directory);
     let opts = SharedSyncOptParamsBuilder::default().build().unwrap();
 
     let res = blocking::sync(
@@ -95,7 +95,7 @@ fn test_sync_up_without_slash() {
         GlobFilter::Exclude(Pattern::new("*").unwrap()),
     ]);
 
-    let source = S3PathParam::new_local(&local_directory);
+    let source = S3PathParam::new_local(local_directory);
     let destination = S3PathParam::new_bucket(esthri_test::TEST_BUCKET, s3_key);
     let opts = SharedSyncOptParamsBuilder::default().build().unwrap();
 
@@ -119,7 +119,7 @@ fn test_sync_up() {
         GlobFilter::Exclude(Pattern::new("*").unwrap()),
     ]);
 
-    let source = S3PathParam::new_local(&local_directory);
+    let source = S3PathParam::new_local(local_directory);
     let destination = S3PathParam::new_bucket(esthri_test::TEST_BUCKET, s3_key);
     let opts = SharedSyncOptParamsBuilder::default().build().unwrap();
 
@@ -164,7 +164,7 @@ fn test_sync_up_default() {
     let local_directory = esthri_test::test_data("sync_up");
     let s3_key = esthri_test::randomised_lifecycled_prefix("test_sync_up_default/");
 
-    let source = S3PathParam::new_local(&local_directory);
+    let source = S3PathParam::new_local(local_directory);
     let destination = S3PathParam::new_bucket(esthri_test::TEST_BUCKET, &s3_key);
     let opts = SharedSyncOptParamsBuilder::default().build().unwrap();
 
@@ -277,7 +277,7 @@ fn test_sync_down_delete() {
     // Create a key that correspods to non-existant data in an S3 bucket
     let s3_key_prefix = esthri_test::randomised_lifecycled_prefix("test_sync_down_delete/");
 
-    let src = S3PathParam::new_bucket(esthri_test::TEST_BUCKET, &s3_key_prefix);
+    let src = S3PathParam::new_bucket(esthri_test::TEST_BUCKET, s3_key_prefix);
     let dst = S3PathParam::new_local(&local_directory);
 
     // Expect contents to have been copied to local directory
@@ -322,7 +322,7 @@ fn test_sync_across_delete() {
     let temp_directory_as_pathbuf = temp_directory.as_ref().to_path_buf();
 
     // Create 2 empty buckets
-    let source = S3PathParam::new_bucket(esthri_test::TEST_BUCKET, &s3_key_src_prefix);
+    let source = S3PathParam::new_bucket(esthri_test::TEST_BUCKET, s3_key_src_prefix);
     let destination = S3PathParam::new_bucket(esthri_test::TEST_BUCKET, &s3_key_dst_prefix);
 
     let local_source = S3PathParam::new_local(temp_directory_as_pathbuf.as_path());
@@ -386,11 +386,11 @@ fn test_sync_across_delete() {
 fn test_sync_down_default() {
     let s3client = esthri_test::get_s3client();
     let local_directory = "tests/data/sync_down/d";
-    let sync_dir_meta = fs::metadata(&local_directory);
+    let sync_dir_meta = fs::metadata(local_directory);
 
     if let Ok(sync_dir_meta) = sync_dir_meta {
         assert!(sync_dir_meta.is_dir());
-        assert!(fs::remove_dir_all(&local_directory).is_ok());
+        assert!(fs::remove_dir_all(local_directory).is_ok());
     }
 
     // Test was data populated with the following command:
@@ -400,7 +400,7 @@ fn test_sync_down_default() {
     let s3_key = "test_sync_down_default/";
 
     let source = S3PathParam::new_bucket(esthri_test::TEST_BUCKET, s3_key);
-    let destination = S3PathParam::new_local(&local_directory);
+    let destination = S3PathParam::new_local(local_directory);
     let opts = SharedSyncOptParamsBuilder::default().build().unwrap();
 
     let res = blocking::sync(s3client.as_ref(), source, destination, FILTER_EMPTY, opts);
@@ -413,7 +413,7 @@ fn test_sync_down_default() {
         KeyHashPair("nested/2MiB.bin", "64a2635e42ef61c69d62feebdbf118d4"),
     ];
 
-    validate_key_hash_pairs(&local_directory, &key_hash_pairs);
+    validate_key_hash_pairs(local_directory, &key_hash_pairs);
 }
 
 #[test]

--- a/crates/esthri/tests/integration/upload_test.rs
+++ b/crates/esthri/tests/integration/upload_test.rs
@@ -18,7 +18,7 @@ fn test_upload() {
         s3client.as_ref(),
         esthri_test::TEST_BUCKET,
         &s3_key,
-        &filepath,
+        filepath,
         opts,
     );
     assert!(res.is_ok());
@@ -49,7 +49,7 @@ fn test_upload_compressed() {
         s3client.as_ref(),
         esthri_test::TEST_BUCKET,
         &s3_key,
-        &filepath,
+        filepath,
         opts,
     );
     assert!(res.is_ok());
@@ -122,8 +122,8 @@ fn test_upload_zero_size() {
     let res = blocking::upload(
         s3client.as_ref(),
         esthri_test::TEST_BUCKET,
-        &s3_key,
-        &filepath,
+        s3_key,
+        filepath,
         opts,
     );
     assert!(res.is_ok());
@@ -133,7 +133,7 @@ fn test_upload_zero_size() {
 fn test_upload_storage_class_all() {
     let s3client = esthri_test::get_s3client();
     let filename = "test5mb.bin";
-    let filepath = esthri_test::test_data(filename);
+    let filepath = &esthri_test::test_data(filename);
     let s3_key = esthri_test::randomised_lifecycled_prefix(&format!("test_upload/{}", filename));
 
     // 1. Glacier Class might take hours to populate metadata, skipping tests...
@@ -155,7 +155,7 @@ fn test_upload_storage_class_all() {
             s3client.as_ref(),
             esthri_test::TEST_BUCKET,
             &s3_key,
-            &filepath,
+            filepath,
             opts,
         );
         assert!(res.is_ok());


### PR DESCRIPTION
Clippy isn't running on --all-targets. This PR fixes all the clippy lints in the testing code. 