### PR TITLE
update proc-macro2 to due to nightly deprecation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1697,9 +1697,9 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.47"
+version = "1.0.63"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5ea3d908b0e36316caf9e9e2c4625cdde190a7e6f440d794667ed17a1855e725"
+checksum = "7b368fba921b0dce7e60f5e04ec15e565b3303972b42bcfde1d0713b881959eb"
 dependencies = [
  "unicode-ident",
 ]


### PR DESCRIPTION
procmacro2 used a feature of nightly rust which as been removed. bumping the version will allow it to compile on latest version of nightly rust.