### PR TITLE
deps: pin hyper-rustls

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -749,7 +749,7 @@ name = "esthri-internals"
 version = "10.0.6"
 dependencies = [
  "hyper",
- "hyper-rustls 0.24.1",
+ "hyper-rustls 0.23.2",
  "hyper-tls",
  "rusoto_core",
  "rusoto_credential",
@@ -1149,6 +1149,7 @@ dependencies = [
  "rustls-native-certs",
  "tokio",
  "tokio-rustls 0.23.4",
+ "webpki-roots",
 ]
 
 [[package]]
@@ -1160,12 +1161,9 @@ dependencies = [
  "futures-util",
  "http",
  "hyper",
- "log",
  "rustls 0.21.0",
- "rustls-native-certs",
  "tokio",
  "tokio-rustls 0.24.0",
- "webpki-roots 0.23.0",
 ]
 
 [[package]]
@@ -1926,7 +1924,7 @@ dependencies = [
  "wasm-bindgen-futures",
  "wasm-streams",
  "web-sys",
- "webpki-roots 0.22.4",
+ "webpki-roots",
  "winreg",
 ]
 
@@ -2975,15 +2973,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f1c760f0d366a6c24a02ed7816e23e691f5d92291f94d15e836006fd11b04daf"
 dependencies = [
  "webpki",
-]
-
-[[package]]
-name = "webpki-roots"
-version = "0.23.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aa54963694b65584e170cf5dc46aeb4dcaa5584e652ff5f3952e56d66aff0125"
-dependencies = [
- "rustls-webpki",
 ]
 
 [[package]]

--- a/crates/esthri-internals/Cargo.toml
+++ b/crates/esthri-internals/Cargo.toml
@@ -31,6 +31,6 @@ version = "0.5"
 optional = true
 
 [dependencies.hyper-rustls]
-version = "0.24"
+version = "=0.23"
 optional = true
 features = ["webpki-roots"]


### PR DESCRIPTION
The lib `rusoto_core` requires hyper-rustls version 0.23 -- this means we are
effectively pinned to this version, I'm not sure why Esthri itself compiles
successfully, but when SITL attempts to use the latest version we get a
duplicate version error where hyper-rustls 0.23 and hyper-rustls 0.24 are
conflicting.
