### PR TITLE
pub use aws-sdk client

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1089,7 +1089,6 @@ dependencies = [
  "async-compression 0.4.3",
  "async-stream",
  "async_zip",
- "aws-sdk-s3",
  "backtrace",
  "bytes",
  "clap",

--- a/crates/esthri-cli/Cargo.toml
+++ b/crates/esthri-cli/Cargo.toml
@@ -51,8 +51,6 @@ tokio = { version = "1.23.0", features = ["rt-multi-thread", "signal", "sync"] }
 tokio-util = { version = "0.7.8", features = ["compat", "codec"] }
 warp = "0.3"
 
-aws-sdk-s3 = { workspace = true }
-
 [dev-dependencies]
 esthri = { path = "../esthri", default-features = false, features=["blocking"] }
 esthri-test = { path = "../esthri-test" }

--- a/crates/esthri-cli/src/cli_opts.rs
+++ b/crates/esthri-cli/src/cli_opts.rs
@@ -1,9 +1,8 @@
-use std::path::PathBuf;
-
-use aws_sdk_s3::types::StorageClass as S3StorageClass;
 use clap::Args;
+use esthri::aws_sdk::StorageClass as S3StorageClass;
 use esthri::{opts::*, S3PathParam};
 use glob::Pattern;
+use std::path::PathBuf;
 
 // Esthri does this by default (and can currently only do this), exposing this
 // as an option just ensures that Esthri will still be able to handle the case

--- a/crates/esthri-cli/src/cli_utils.rs
+++ b/crates/esthri-cli/src/cli_utils.rs
@@ -1,17 +1,16 @@
+use anyhow::{bail, Result};
+use clap::ArgMatches;
+use esthri::aws_sdk::Client as S3Client;
+use esthri::{AwsCredProvider, GlobFilter};
+use glob::Pattern;
+use log::*;
+use log_derive::logfn;
 use std::{
     env,
     ffi::OsStr,
     path::Path,
     process::{Command, Stdio},
 };
-
-use anyhow::{bail, Result};
-use aws_sdk_s3::Client as S3Client;
-use clap::ArgMatches;
-use esthri::{AwsCredProvider, GlobFilter};
-use glob::Pattern;
-use log::*;
-use log_derive::logfn;
 
 // Environment variable that can be set to set the path to the aws tool that esthri falls back to
 const REAL_AWS_EXECUTABLE_ENV_NAME: &str = "ESTHRI_AWS_PATH";

--- a/crates/esthri-cli/src/http_server.rs
+++ b/crates/esthri-cli/src/http_server.rs
@@ -26,8 +26,8 @@ use async_zip::{
     write::{EntryOptions, ZipFileWriter},
     Compression,
 };
-use aws_sdk_s3::Client as S3Client;
 use bytes::{Bytes, BytesMut};
+use esthri::aws_sdk::Client as S3Client;
 use futures::stream::{Stream, StreamExt, TryStreamExt};
 use hyper::header::{CONTENT_ENCODING, LOCATION};
 use log::*;

--- a/crates/esthri-cli/src/main.rs
+++ b/crates/esthri-cli/src/main.rs
@@ -19,14 +19,13 @@ mod cli_utils;
 
 use anyhow::Result;
 use clap::{CommandFactory, Parser, Subcommand};
+use cli_opts::*;
+use cli_utils::*;
+use esthri::aws_sdk::Client as S3Client;
+use esthri::{self, GlobFilter, PendingUpload};
 use glob::Pattern;
 use log::*;
 use tokio::runtime::Builder;
-
-use aws_sdk_s3::Client as S3Client;
-use cli_opts::*;
-use cli_utils::*;
-use esthri::{self, GlobFilter, PendingUpload};
 
 #[derive(Debug, Parser)]
 #[clap(name = "esthri", about = "Simple S3 file transfer utility.", version)]

--- a/crates/esthri/src/aws_sdk.rs
+++ b/crates/esthri/src/aws_sdk.rs
@@ -17,14 +17,16 @@ use aws_sdk_s3::operation::create_multipart_upload::CreateMultipartUploadOutput;
 use aws_sdk_s3::operation::get_object::GetObjectOutput;
 use aws_sdk_s3::operation::head_object::{HeadObjectError, HeadObjectOutput};
 use aws_sdk_s3::primitives::ByteStream;
-use aws_sdk_s3::types::{CompletedMultipartUpload, CompletedPart, StorageClass};
-use aws_sdk_s3::Client;
+use aws_sdk_s3::types::{CompletedMultipartUpload, CompletedPart};
 use aws_smithy_types_convert::date_time::DateTimeExt;
 use bytes::Bytes;
 use chrono::{DateTime, Utc};
 use futures::Stream;
 
 use crate::{Error, Result};
+
+pub use aws_sdk_s3::types::StorageClass;
+pub use aws_sdk_s3::Client;
 
 /// The data returned from a head object request
 #[derive(Debug)]

--- a/crates/esthri/src/lib.rs
+++ b/crates/esthri/src/lib.rs
@@ -58,6 +58,7 @@ pub use presign::{
     upload::{presign_put, upload_file_presigned},
 };
 
+pub use aws_sdk::HeadObjectInfo;
 pub use aws_smithy_client::hyper_ext;
 pub use types::{S3ListingItem, S3Object, S3PathParam};
 

--- a/crates/esthri/src/lib.rs
+++ b/crates/esthri/src/lib.rs
@@ -58,9 +58,7 @@ pub use presign::{
     upload::{presign_put, upload_file_presigned},
 };
 
-pub use aws_sdk::HeadObjectInfo;
-use aws_sdk_s3::Client;
-use aws_smithy_client::hyper_ext;
+pub use aws_smithy_client::hyper_ext;
 pub use types::{S3ListingItem, S3Object, S3PathParam};
 
 pub use esthri_internals::new_https_connector;


### PR DESCRIPTION
Re-exports `aws_sdk_s3`
```rust
use esthri::aws_sdk::Client;
// use aws_sdk_s3::Client

pub static S3_CLIENT: OnceCell<Client> = OnceCell::const_new();

pub async fn init_s3_client() {
    let client = init_default_s3client().await;
    S3_CLIENT.set(client).unwrap();
}
```
without pulling in `aws_sdk_s3` dependency

1. Unsure if I've exported all the necessary types - this just exposes StorageClass and Client
2. This exports as Client instead of S3Client, under esthri::aws_sdk, might be confusing compared to previous versions