### PR TITLE
bug-fix: ensure task Send safety for download function

### DIFF
--- a/crates/esthri/src/aws_sdk.rs
+++ b/crates/esthri/src/aws_sdk.rs
@@ -131,7 +131,7 @@ pub struct GetObjectResponse {
 }
 
 impl GetObjectResponse {
-    pub fn into_stream<'a>(self) -> impl Stream<Item = Result<Bytes>> {
+    pub fn into_stream(self) -> impl Stream<Item = Result<Bytes>> {
         TryStreamExt::map_err(self.stream, |e| Error::ByteStreamError(e.to_string()))
     }
 }

--- a/crates/esthri/src/aws_sdk.rs
+++ b/crates/esthri/src/aws_sdk.rs
@@ -21,7 +21,7 @@ use aws_sdk_s3::types::{CompletedMultipartUpload, CompletedPart};
 use aws_smithy_types_convert::date_time::DateTimeExt;
 use bytes::Bytes;
 use chrono::{DateTime, Utc};
-use futures::Stream;
+use futures::{Stream, TryStreamExt};
 
 use crate::{Error, Result};
 
@@ -131,8 +131,8 @@ pub struct GetObjectResponse {
 }
 
 impl GetObjectResponse {
-    pub fn into_stream(self) -> impl Stream<Item = Result<Bytes>> {
-        futures::TryStreamExt::map_err(self.stream, |e| Error::ByteStreamError(e.to_string()))
+    pub fn into_stream<'a>(self) -> impl Stream<Item = Result<Bytes>> {
+        TryStreamExt::map_err(self.stream, |e| Error::ByteStreamError(e.to_string()))
     }
 }
 

--- a/crates/esthri/src/ops/download.rs
+++ b/crates/esthri/src/ops/download.rs
@@ -211,13 +211,11 @@ async fn init_download_dir(path: &Path) -> Result<PathBuf> {
 #[cfg(unix)]
 async fn write_all_at(file: Arc<std::fs::File>, buf: Bytes, offset: u64) -> Result<()> {
     use std::os::unix::prelude::FileExt;
-
     tokio::task::spawn_blocking(move || {
         file.write_all_at(&buf, offset)?;
         Ok(())
     })
-    .await??;
-    Ok(())
+    .await?
 }
 
 #[cfg(windows)]

--- a/crates/esthri/src/ops/download.rs
+++ b/crates/esthri/src/ops/download.rs
@@ -127,20 +127,17 @@ async fn download_file(
     } else {
         let dest = &Arc::new(dest.take_std_file().await);
         let part_size = obj_info.size;
-        let stream = download_unordered_streaming_helper(s3, bucket, key, obj_info.parts);
-        stream
-            .try_for_each_concurrent(
-                Config::global().concurrent_writer_tasks(),
-                |(part, mut chunks)| async move {
-                    let mut offset = (part - 1) * part_size;
-                    while let Some(buf) = chunks.try_next().await? {
-                        let len = buf.len();
-                        write_all_at(Arc::clone(dest), buf, offset as u64).await?;
-                        offset += len as i64;
-                    }
-                    Ok(())
-                },
-            )
+        let limit = Config::global().concurrent_writer_tasks();
+        download_unordered_streaming_helper(s3, bucket, key, obj_info.parts)
+            .try_for_each_concurrent(limit, |(part, mut chunks)| async move {
+                let mut offset = (part - 1) * part_size;
+                while let Some(buf) = chunks.try_next().await? {
+                    let len = buf.len();
+                    write_all_at(dest.clone(), buf, offset as u64).await?;
+                    offset += len as i64;
+                }
+                Ok(())
+            })
             .await?;
     };
 
@@ -217,7 +214,7 @@ async fn write_all_at(file: Arc<std::fs::File>, buf: Bytes, offset: u64) -> Resu
 
     tokio::task::spawn_blocking(move || {
         file.write_all_at(&buf, offset)?;
-        Result::Ok(())
+        Ok(())
     })
     .await??;
     Ok(())

--- a/crates/esthri/src/ops/download.rs
+++ b/crates/esthri/src/ops/download.rs
@@ -221,7 +221,6 @@ async fn write_all_at(file: Arc<std::fs::File>, buf: Bytes, offset: u64) -> Resu
 #[cfg(windows)]
 async fn write_all_at(file: Arc<std::fs::File>, buf: Bytes, offset: u64) -> Result<()> {
     use std::os::windows::prelude::FileExt;
-
     tokio::task::spawn_blocking(move || {
         let (mut offset, mut length) = (offset, buf.len());
         let mut buffer_offset = 0;
@@ -233,8 +232,7 @@ async fn write_all_at(file: Arc<std::fs::File>, buf: Bytes, offset: u64) -> Resu
             offset += write_size as u64;
             buffer_offset += write_size;
         }
-        Result::Ok(())
+        Ok(())
     })
-    .await??;
-    Ok(())
+    .await?
 }


### PR DESCRIPTION
fixing error:
```rust
error: higher-ranked lifetime error
  --> crates/esthri/tests/integration/main.rs:26:5
   |
26 | /     tokio::spawn(async move {
27 | |         // println!("{:?}", s3client.as_ref());
28 | |         let s = s3client;
29 | |         esthri::download(
...  |
39 | |         .unwrap();
40 | |     });
   | |______^
   |
   = note: could not prove `[async block@crates/esthri/tests/integration/main.rs:26:18: 40:6]: std::marker::Send`
```