### PR TITLE
release 11.0.3

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1126,7 +1126,7 @@ dependencies = [
 
 [[package]]
 name = "esthri-test"
-version = "11.0.2"
+version = "11.0.3"
 dependencies = [
  "aws-config",
  "aws-sdk-s3",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1036,7 +1036,7 @@ dependencies = [
 
 [[package]]
 name = "esthri"
-version = "11.0.2"
+version = "11.0.3"
 dependencies = [
  "assert_cmd",
  "async-compression 0.4.3",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1082,7 +1082,7 @@ dependencies = [
 
 [[package]]
 name = "esthri-cli"
-version = "11.0.2"
+version = "11.0.3"
 dependencies = [
  "anyhow",
  "assert_cmd",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1117,7 +1117,7 @@ dependencies = [
 
 [[package]]
 name = "esthri-internals"
-version = "11.0.2"
+version = "11.0.3"
 dependencies = [
  "hyper",
  "hyper-rustls 0.23.2",

--- a/crates/esthri-cli/Cargo.toml
+++ b/crates/esthri-cli/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "esthri-cli"
 description = "Extremely simple (memory stable) S3 client that supports get, put, head, list, and sync."
-version = "11.0.2"
+version = "11.0.3"
 authors = ["Swift Navigation <dev@swift-nav.com>"]
 edition = "2018"
 license = "MIT"

--- a/crates/esthri-internals/Cargo.toml
+++ b/crates/esthri-internals/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "esthri-internals"
 description = "Internals common to esthri crates"
-version = "11.0.2"
+version = "11.0.3"
 authors = ["Swift Navigation <dev@swift-nav.com>"]
 edition = "2018"
 license = "MIT"

--- a/crates/esthri-test/Cargo.toml
+++ b/crates/esthri-test/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "esthri-test"
 description = "Tests for esthri"
-version = "11.0.2"
+version = "11.0.3"
 authors = ["Swift Navigation <dev@swift-nav.com>"]
 edition = "2018"
 license = "MIT"

--- a/crates/esthri/Cargo.toml
+++ b/crates/esthri/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "esthri"
 description = "Extremely simple (memory stable) S3 client that supports get, put, head, list, and sync."
-version = "11.0.2"
+version = "11.0.3"
 authors = ["Swift Navigation <dev@swift-nav.com>"]
 edition = "2018"
 license = "MIT"


### PR DESCRIPTION
small bump to resolve #571 bug fixes for sending sync command into threads.
there is a known issue with cargo run for [DIP-343] but this release unblocks device pool for good

[DIP-343]: https://swift-nav.atlassian.net/browse/DIP-343?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ