### PR TITLE
support creation of aws clients in a blocking context

### DIFF
--- a/crates/esthri/src/aws_sdk.rs
+++ b/crates/esthri/src/aws_sdk.rs
@@ -26,7 +26,7 @@ use futures::{Stream, TryStreamExt};
 use crate::{Error, Result};
 
 pub use aws_sdk_s3::types::StorageClass;
-pub use aws_sdk_s3::Client;
+pub use aws_sdk_s3::{config::Region, Client};
 
 /// The data returned from a head object request
 #[derive(Debug)]

--- a/crates/esthri/src/blocking.rs
+++ b/crates/esthri/src/blocking.rs
@@ -16,6 +16,11 @@ use std::path::Path;
 use crate::{ops::sync::GlobFilter, opts::*, HeadObjectInfo, Result, S3PathParam};
 
 #[tokio::main]
+pub async fn build_s3_client(region: Option<impl AsRef<str>>) -> Client {
+    crate::init_default_s3client_with_region(region).await
+}
+
+#[tokio::main]
 pub async fn head_object(
     s3: &Client,
     bucket: impl AsRef<str>,

--- a/crates/esthri/src/lib.rs
+++ b/crates/esthri/src/lib.rs
@@ -76,17 +76,35 @@ pub enum AwsCredProvider {
 }
 
 pub async fn init_default_s3client() -> Client {
-    init_s3client(AwsCredProvider::DefaultProvider).await
+    init_default_s3client_with_region(None::<&str>).await
+}
+
+pub async fn init_default_s3client_with_region(region: Option<impl AsRef<str>>) -> Client {
+    init_s3client_with_region(AwsCredProvider::DefaultProvider, region).await
 }
 
 pub async fn init_s3client(provider: AwsCredProvider) -> Client {
+    init_s3client_with_region(provider, None::<&str>).await
+}
+
+pub async fn init_s3client_with_region(
+    provider: AwsCredProvider,
+    region: Option<impl AsRef<str>>,
+) -> Client {
     let retry_config = aws_config::retry::RetryConfig::standard()
         .with_initial_backoff(Duration::from_millis(500))
         .with_max_attempts(5);
     let https_connector = new_https_connector();
     let smithy_connector = hyper_ext::Adapter::builder().build(https_connector);
 
-    let sdk_config = aws_config::load_from_env().await;
+    let sdk_config = if let Some(region) = region {
+        aws_config::from_env()
+            .region(Region::new(region.as_ref().to_owned()))
+            .load()
+            .await
+    } else {
+        aws_config::load_from_env().await
+    };
     let config = match provider {
         AwsCredProvider::DefaultProvider => aws_sdk_s3::config::Builder::from(&sdk_config)
             .retry_config(retry_config)

--- a/crates/esthri/src/lib.rs
+++ b/crates/esthri/src/lib.rs
@@ -75,18 +75,25 @@ pub enum AwsCredProvider {
     WebIdentityToken,
 }
 
+/// This function builds a AWS client using the default AWS region
+/// and default credentials_provider
 pub async fn init_default_s3client() -> Client {
     init_default_s3client_with_region(None::<&str>).await
 }
 
+/// This function builds a AWS client using default credentials_provider,
+/// allowing you to optionally override the default aws_region
 pub async fn init_default_s3client_with_region(region: Option<impl AsRef<str>>) -> Client {
     init_s3client_with_region(AwsCredProvider::DefaultProvider, region).await
 }
 
+/// This function builds a AWS client using the default AWS region.
 pub async fn init_s3client(provider: AwsCredProvider) -> Client {
     init_s3client_with_region(provider, None::<&str>).await
 }
 
+/// This function builds a AWS client, while allowing you to optionally
+/// override the default aws region.
 pub async fn init_s3client_with_region(
     provider: AwsCredProvider,
     region: Option<impl AsRef<str>>,


### PR DESCRIPTION
Esthri supports calling some function in a blocking context using the `#[tokio::main]` macro. Unfortunately with the move to the aws_sdk crate, the new aws client can only be created in an async function, sort of completely destroying the point of the blocking.rs module.

Here I added the ability to create a default client in a blocking context, so one can use blocking.rs modules functions in an e2e scenario in a different crate.

In addition, I want to be able to specify the client's region, so I added that to the s3 client initiator.