### PR TITLE
bug-fix: esthri sync cli command fails on duplicate naming [DIP-343]

### DIFF
--- a/crates/esthri-cli/src/main.rs
+++ b/crates/esthri-cli/src/main.rs
@@ -182,25 +182,18 @@ async fn dispatch_esthri_cli(cmd: EsthriCommand, s3: &S3Client) -> Result<()> {
             setup_upload_termination_handler(s3.clone());
             let opts = EsthriSyncParams::build_opts(&params);
             if params.transparent_compression
-                && (params.source.is_bucket() && params.destination.is_bucket())
+                && params.source.is_bucket()
+                && params.destination.is_bucket()
             {
                 return Err(esthri::errors::Error::InvalidSyncCompress.into());
             }
-
-            let command = EsthriCommand::augment_subcommands(EsthriCli::command());
-            let matches = command.get_matches();
+            let matches = EsthriCli::command().get_matches();
             let matches = matches
                 .subcommand_matches("sync")
                 .expect("Expected sync command");
             let filters = globs_to_filter_list(&opts.include, &opts.exclude, matches);
-            esthri::sync(
-                s3,
-                params.source.clone(),
-                params.destination.clone(),
-                filters.as_deref(),
-                opts,
-            )
-            .await?;
+            let filters = filters.as_deref();
+            esthri::sync(s3, params.source, params.destination, filters, opts).await?;
         }
 
         HeadObject(params) => {


### PR DESCRIPTION
resolves:
```
[2023-10-02T21:26:21Z INFO  esthri] Starting, using region: UsWest2...
thread 'main' panicked at 'Command esthri: command name `put` is duplicated', /Users/adriankong/.cargo/registry/src/index.crates.io-6f17d22bba15001f/clap-4.0.26/src/builder/debug_asserts.rs:329:9
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
zsh: abort      cargo run sync --source s3://swiftnav-releases/swift-cli --destination .
```