### PR TITLE
Remove unnecessary panics

### DIFF
--- a/crates/esthri-cli/src/http_server.rs
+++ b/crates/esthri-cli/src/http_server.rs
@@ -395,7 +395,9 @@ async fn create_archive_stream(
                     Ok(None) => break,
                     Ok(Some(items)) => {
                         for s3obj in items {
-                            let s3obj = s3obj.unwrap_object();
+                            let s3obj = s3obj
+                                .as_object()
+                                .expect("list_objects_stream only returns objects");
                             if !stream_object_to_archive(
                                 &s3,
                                 &bucket,

--- a/crates/esthri/src/lib.rs
+++ b/crates/esthri/src/lib.rs
@@ -376,31 +376,32 @@ async fn list_objects_request(
 
     if let Some(contents) = lov2o.contents {
         for object in contents {
-            let key = if object.key.is_some() {
-                object.key.unwrap()
-            } else {
-                warn!("unexpected: object key was null");
-                continue;
-            };
-            let e_tag = if object.e_tag.is_some() {
-                object.e_tag.unwrap()
-            } else {
-                warn!("unexpected: object ETag was null");
-                continue;
-            };
-            listing.contents.push(S3Object { key, e_tag });
+            match (object.key, object.e_tag) {
+                (Some(key), Some(e_tag)) => {
+                    listing.contents.push(S3Object { key, e_tag });
+                }
+                (key, etag) => {
+                    if key.is_none() {
+                        warn!("unexpected: object key was null");
+                    }
+                    if etag.is_none() {
+                        warn!("unexpected: object ETag was null");
+                    }
+                    continue;
+                }
+            }
         }
     }
 
     if let Some(common_prefixes) = lov2o.common_prefixes {
         for common_prefix in common_prefixes {
-            let prefix = if common_prefix.prefix.is_some() {
-                common_prefix.prefix.unwrap()
-            } else {
-                warn!("unexpected: prefix was null");
-                continue;
-            };
-            listing.common_prefixes.push(prefix);
+            match common_prefix.prefix {
+                Some(prefix) => listing.common_prefixes.push(prefix),
+                None => {
+                    warn!("unexpected: prefix was null");
+                    continue;
+                }
+            }
         }
     }
 

--- a/crates/esthri/src/types.rs
+++ b/crates/esthri/src/types.rs
@@ -115,6 +115,13 @@ impl S3ListingItem {
             S3ListingItem::S3CommonPrefix(_cp) => panic!("invalid type"),
         }
     }
+
+    pub fn as_object(self) -> Option<S3Object> {
+        match self {
+            S3ListingItem::S3Object(o) => Some(o),
+            S3ListingItem::S3CommonPrefix(_cp) => None,
+        }
+    }
 }
 
 #[derive(Default)]


### PR DESCRIPTION
> Don't Panic. It's the first helpful or intelligible thing anybody's said to me all day
- Douglas Adams

This PR removes some unwraps throughout the esthri code. In some cases they are replaced by `expects` because they are things that should be guaranteed but not enforced by the type system. The expects have the reason why they should be safe. In other cases, i have cast them to errors so they can be properly handled by other people using the esthri crate.