### PR TITLE
bump async_zip to latest

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -85,19 +85,15 @@ dependencies = [
 
 [[package]]
 name = "async-compression"
-version = "0.3.12"
+version = "0.3.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f2bf394cfbbe876f0ac67b13b6ca819f9c9f2fb9ec67223cceb1555fbab1c31a"
+checksum = "942c7cd7ae39e91bde4820d74132e9862e62c2f386c3aa90ccf55949f5bad63a"
 dependencies = [
- "bzip2",
  "flate2",
  "futures-core",
+ "futures-io",
  "memchr",
  "pin-project-lite",
- "tokio",
- "xz2",
- "zstd",
- "zstd-safe",
 ]
 
 [[package]]
@@ -136,26 +132,19 @@ dependencies = [
 ]
 
 [[package]]
-name = "async_io_utilities"
-version = "0.1.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9b20cffc5590f4bf33f05f97a3ea587feba9c50d20325b401daa096b92ff7da0"
-dependencies = [
- "tokio",
-]
-
-[[package]]
 name = "async_zip"
-version = "0.0.7"
+version = "0.0.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f0a5c419dca9559f15d04befbf9ff01c39ca16d4c0abd56f60daaf87a386b929"
+checksum = "795310de3218cde15219fc98c1cf7d8fe9db4865aab27fcf1d535d6cb61c6b54"
 dependencies = [
- "async-compression 0.3.12",
- "async_io_utilities",
- "chrono",
+ "async-compression 0.3.15",
  "crc32fast",
+ "futures-util",
+ "log",
+ "pin-project",
  "thiserror",
  "tokio",
+ "tokio-util",
 ]
 
 [[package]]
@@ -1700,17 +1689,6 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 1.0.105",
-]
-
-[[package]]
-name = "lzma-sys"
-version = "0.1.19"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e06754c4acf47d49c727d5665ca9fb828851cda315ed3bd51edd148ef78a8772"
-dependencies = [
- "cc",
- "libc",
- "pkg-config",
 ]
 
 [[package]]
@@ -3499,15 +3477,6 @@ name = "xmlparser"
 version = "0.13.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4d25c75bf9ea12c4040a97f829154768bbbce366287e2dc044af160cd79a13fd"
-
-[[package]]
-name = "xz2"
-version = "0.1.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "388c44dc09d76f1536602ead6d325eb532f5c122f17782bd57fb47baeeb767e2"
-dependencies = [
- "lzma-sys",
-]
 
 [[package]]
 name = "zeroize"

--- a/crates/esthri-cli/Cargo.toml
+++ b/crates/esthri-cli/Cargo.toml
@@ -31,7 +31,7 @@ path = "src/http_server.rs"
 esthri = { version = "11.1.0", path = "../esthri", default-features = false }
 anyhow = { version = "1", features = ["backtrace"] }
 async-compression = { version = "0.4", features = ["gzip", "tokio"] }
-async_zip = "0.0.7"
+async_zip = { version = "0.0.15", features = ["deflate", "tokio", "tokio-fs"] }
 async-stream = "0.3"
 bytes = "1.0"
 derive_builder = "0.12.0"

--- a/crates/esthri-cli/Cargo.toml
+++ b/crates/esthri-cli/Cargo.toml
@@ -31,7 +31,7 @@ path = "src/http_server.rs"
 esthri = { version = "11.1.0", path = "../esthri", default-features = false }
 anyhow = { version = "1", features = ["backtrace"] }
 async-compression = { version = "0.4", features = ["gzip", "tokio"] }
-async_zip = { version = "0.0.15", features = ["deflate", "tokio", "tokio-fs"] }
+async_zip = { version = "0.0.15", features = ["deflate", "tokio"] }
 async-stream = "0.3"
 bytes = "1.0"
 derive_builder = "0.12.0"


### PR DESCRIPTION
This PR handles the upgrading of `async_zip` to the latest version. They did some work around supporting multiple async runtimes which we really don't benefit from here because we are just using tokio.

Anyway, this gets us unstuck from async_zip 0.7